### PR TITLE
Implement admin schedule override functionality 

### DIFF
--- a/Backend/routers/admin.py
+++ b/Backend/routers/admin.py
@@ -4,8 +4,10 @@ from Backend.services.plan_service import (
     load_courses_from_plan,
     save_courses_to_plan,
     list_student_plans,
+    load_registered_courses,
+    register_courses,
 )
-from Backend.schemas.plan_schema import AdminCourseList
+from Backend.schemas.plan_schema import AdminCourseList, AdminRegisterCourseList
 
 router = APIRouter()
 
@@ -47,6 +49,19 @@ def admin_load_student_plan(
         name=name
     )
 
+
+@router.get("/plans/registered")
+def admin_get_registered(
+    admin_user: str = Query(...),
+    student_id: str = Query(...),
+):
+    _verify_admin(admin_user)
+    return load_registered_courses(student_id)
+
+@router.post("/plans/register")
+def admin_register_student_plan(data: AdminRegisterCourseList):
+    _verify_admin(data.admin_user)
+    return register_courses(user=data.student_id, course_ids=data.course_ids)
 
 @router.post("/plans/save")
 def admin_save_student_plan(data: AdminCourseList):

--- a/Backend/routers/admin.py
+++ b/Backend/routers/admin.py
@@ -1,16 +1,12 @@
 from fastapi import APIRouter, Query, HTTPException
 from Backend.services.auth_service import get_users
-from Backend.services.plan_service import load_courses_from_plan
+from Backend.services.plan_service import load_courses_from_plan, save_courses_to_plan
+from Backend.schemas.plan_schema import AdminCourseList
 
 router = APIRouter()
 
-@router.get("/plans/load")
-def admin_load_student_plan(
-    admin_user: str = Query(...),
-    student_id: str = Query(...),
-    term: int = Query(...),
-    name: str = Query(...)
-):
+
+def _verify_admin(admin_user: str):
     users = get_users()
     admin = users.get(admin_user)
 
@@ -20,8 +16,32 @@ def admin_load_student_plan(
     if admin["role"] != "admin":
         raise HTTPException(status_code=403, detail="Admin access required")
 
+    return admin
+
+
+@router.get("/plans/load")
+def admin_load_student_plan(
+    admin_user: str = Query(...),
+    student_id: str = Query(...),
+    term: int = Query(...),
+    name: str = Query(...)
+):
+    _verify_admin(admin_user)
+
     return load_courses_from_plan(
         user=student_id,
         term=term,
         name=name
+    )
+
+
+@router.post("/plans/save")
+def admin_save_student_plan(data: AdminCourseList):
+    _verify_admin(data.admin_user)
+
+    return save_courses_to_plan(
+        course_ids=data.course_ids,
+        user=data.student_id,
+        term=data.term,
+        name=data.name
     )

--- a/Backend/routers/admin.py
+++ b/Backend/routers/admin.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Query, HTTPException
-from services.auth_service import get_users
-from services.plan_service import load_courses_from_plan
+from Backend.services.auth_service import get_users
+from Backend.services.plan_service import load_courses_from_plan
 
 router = APIRouter()
 

--- a/Backend/routers/admin.py
+++ b/Backend/routers/admin.py
@@ -1,16 +1,16 @@
 from fastapi import APIRouter, Query, HTTPException
 from Backend.services.auth_service import get_users
-from Backend.services.plan_service import load_courses_from_plan
+from Backend.services.plan_service import (
+    load_courses_from_plan,
+    save_courses_to_plan,
+    list_student_plans,
+)
+from Backend.schemas.plan_schema import AdminCourseList
 
 router = APIRouter()
 
-@router.get("/plans/load")
-def admin_load_student_plan(
-    admin_user: str = Query(...),
-    student_id: str = Query(...),
-    term: int = Query(...),
-    name: str = Query(...)
-):
+
+def _verify_admin(admin_user: str):
     users = get_users()
     admin = users.get(admin_user)
 
@@ -20,8 +20,41 @@ def admin_load_student_plan(
     if admin["role"] != "admin":
         raise HTTPException(status_code=403, detail="Admin access required")
 
+    return admin
+
+
+@router.get("/plans/list")
+def admin_list_student_plans(
+    admin_user: str = Query(...),
+    student_id: str = Query(...),
+):
+    _verify_admin(admin_user)
+    return list_student_plans(student_id)
+
+
+@router.get("/plans/load")
+def admin_load_student_plan(
+    admin_user: str = Query(...),
+    student_id: str = Query(...),
+    term: int = Query(...),
+    name: str = Query(...)
+):
+    _verify_admin(admin_user)
+
     return load_courses_from_plan(
         user=student_id,
         term=term,
         name=name
+    )
+
+
+@router.post("/plans/save")
+def admin_save_student_plan(data: AdminCourseList):
+    _verify_admin(data.admin_user)
+
+    return save_courses_to_plan(
+        course_ids=data.course_ids,
+        user=data.student_id,
+        term=data.term,
+        name=data.name
     )

--- a/Backend/routers/admin.py
+++ b/Backend/routers/admin.py
@@ -1,12 +1,16 @@
 from fastapi import APIRouter, Query, HTTPException
 from Backend.services.auth_service import get_users
-from Backend.services.plan_service import load_courses_from_plan, save_courses_to_plan
-from Backend.schemas.plan_schema import AdminCourseList
+from Backend.services.plan_service import load_courses_from_plan
 
 router = APIRouter()
 
-
-def _verify_admin(admin_user: str):
+@router.get("/plans/load")
+def admin_load_student_plan(
+    admin_user: str = Query(...),
+    student_id: str = Query(...),
+    term: int = Query(...),
+    name: str = Query(...)
+):
     users = get_users()
     admin = users.get(admin_user)
 
@@ -16,32 +20,8 @@ def _verify_admin(admin_user: str):
     if admin["role"] != "admin":
         raise HTTPException(status_code=403, detail="Admin access required")
 
-    return admin
-
-
-@router.get("/plans/load")
-def admin_load_student_plan(
-    admin_user: str = Query(...),
-    student_id: str = Query(...),
-    term: int = Query(...),
-    name: str = Query(...)
-):
-    _verify_admin(admin_user)
-
     return load_courses_from_plan(
         user=student_id,
         term=term,
         name=name
-    )
-
-
-@router.post("/plans/save")
-def admin_save_student_plan(data: AdminCourseList):
-    _verify_admin(data.admin_user)
-
-    return save_courses_to_plan(
-        course_ids=data.course_ids,
-        user=data.student_id,
-        term=data.term,
-        name=data.name
     )

--- a/Backend/routers/plans.py
+++ b/Backend/routers/plans.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Query
 from Backend.schemas.plan_schema import CourseList
-from Backend.services.plan_service import save_courses_to_plan,load_courses_from_plan,load_plans_from_user
+from Backend.services.plan_service import save_courses_to_plan, load_courses_from_plan, load_plans_from_user, list_student_plans
 
 router = APIRouter()
 
@@ -20,6 +20,10 @@ def load_courses(user: str, term: int, name: str):
         term=term,
         name=name
     )
+
+@router.get("/list")
+def list_plans(user: str):
+    return list_student_plans(user)
 
 @router.post("/load-plans")
 def load_plans(user: str):

--- a/Backend/routers/plans.py
+++ b/Backend/routers/plans.py
@@ -1,6 +1,13 @@
 from fastapi import APIRouter, Query
-from Backend.schemas.plan_schema import CourseList
-from Backend.services.plan_service import save_courses_to_plan, load_courses_from_plan, load_plans_from_user, list_student_plans
+from Backend.schemas.plan_schema import CourseList, RegisterCourseList
+from Backend.services.plan_service import (
+    save_courses_to_plan,
+    load_courses_from_plan,
+    load_plans_from_user,
+    list_student_plans,
+    register_courses,
+    load_registered_courses,
+)
 
 router = APIRouter()
 
@@ -20,6 +27,14 @@ def load_courses(user: str, term: int, name: str):
         term=term,
         name=name
     )
+
+@router.post("/register")
+def register(data: RegisterCourseList):
+    return register_courses(user=data.user, course_ids=data.course_ids)
+
+@router.get("/registered")
+def get_registered(user: str):
+    return load_registered_courses(user)
 
 @router.get("/list")
 def list_plans(user: str):

--- a/Backend/schemas/plan_schema.py
+++ b/Backend/schemas/plan_schema.py
@@ -6,9 +6,18 @@ class CourseList(BaseModel):
     term: int
     name: str
 
+class RegisterCourseList(BaseModel):
+    user: str
+    course_ids: list[int]
+
 class AdminCourseList(BaseModel):
     admin_user: str
     student_id: str
     course_ids: list[int]
     term: int
     name: str
+
+class AdminRegisterCourseList(BaseModel):
+    admin_user: str
+    student_id: str
+    course_ids: list[int]

--- a/Backend/schemas/plan_schema.py
+++ b/Backend/schemas/plan_schema.py
@@ -5,3 +5,10 @@ class CourseList(BaseModel):
     user: str
     term: int
     name: str
+
+class AdminCourseList(BaseModel):
+    admin_user: str
+    student_id: str
+    course_ids: list[int]
+    term: int
+    name: str

--- a/Backend/services/plan_service.py
+++ b/Backend/services/plan_service.py
@@ -144,6 +144,98 @@ def load_plans_from_user(user: str):
         conn.close()
 
 
+REGISTERED_PLAN_NAME = "__registered__"
+
+
+def register_courses(user: str, course_ids: list[int]):
+    conn = get_conn()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            "DELETE FROM plan WHERE student_id = %s AND name = %s",
+            (user, REGISTERED_PLAN_NAME),
+        )
+        for cid in course_ids:
+            cur.execute(
+                "INSERT INTO plan (student_id, course_id, term_id, name, is_active, updated_at) "
+                "VALUES (%s, %s, 0, %s, true, NOW())",
+                (user, cid, REGISTERED_PLAN_NAME),
+            )
+        conn.commit()
+    except Exception as e:
+        conn.rollback()
+        raise HTTPException(status_code=500, detail=f"Failed to register: {e}")
+    finally:
+        conn.close()
+    return {"success": True, "registered": course_ids}
+
+
+def load_registered_courses(user: str):
+    conn = get_conn()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT course_id FROM plan WHERE student_id = %s AND name = %s",
+            (user, REGISTERED_PLAN_NAME),
+        )
+        course_ids = [r["course_id"] for r in cur.fetchall()]
+
+        if not course_ids:
+            return {"results": []}
+
+        sql = """
+        SELECT
+            s."CRN" AS crn, s.term_id, s.max_reg, s.registered,
+            c.id AS course_id, c.subject, c.course_number, c.title,
+            c.credit_hours, c.instructor, c.building, c.room_number,
+            t.monday, t.tuesday, t.wednesday, t.thursday, t.friday,
+            t.start_min, t.end_min
+        FROM section s
+        JOIN course c ON c.id = s.course_id
+        LEFT JOIN time_slot t ON t.id = c.id
+        WHERE c.id = ANY(%s)
+        ORDER BY c.subject, c.course_number
+        """
+        cur.execute(sql, (course_ids,))
+        rows = cur.fetchall()
+    finally:
+        conn.close()
+
+    results = []
+    for r in rows:
+        max_seats = r["max_reg"] or 0
+        registered_seats = r["registered"] or 0
+        results.append({
+            "courseId": r["course_id"],
+            "subject": r["subject"],
+            "courseNumber": r["course_number"],
+            "courseCode": f"{r['subject']} {r['course_number']}",
+            "crn": str(r["crn"]),
+            "term": str(r["term_id"]),
+            "name": r["title"],
+            "credits": r["credit_hours"],
+            "instructor": r["instructor"] or "TBA",
+            "days": days_str(r),
+            "time": format_time_range(r),
+            "location": format_location(r),
+            "meetingDays": days_str(r),
+            "meetingTime": format_time_range(r),
+            "building": r["building"],
+            "room": r["room_number"],
+            "startMin": r["start_min"],
+            "endMin": r["end_min"],
+            "monday": r["monday"],
+            "tuesday": r["tuesday"],
+            "wednesday": r["wednesday"],
+            "thursday": r["thursday"],
+            "friday": r["friday"],
+            "maxSeats": max_seats,
+            "registeredSeats": registered_seats,
+            "availableSeats": max_seats - registered_seats,
+        })
+    return {"results": results}
+
+
 def list_student_plans(user: str):
     conn = get_conn()
     try:
@@ -154,11 +246,11 @@ def list_student_plans(user: str):
                COUNT(course_id) AS course_count,
                MAX(updated_at) AS last_updated
         FROM plan
-        WHERE student_id = %s
+        WHERE student_id = %s AND name != %s
         GROUP BY name, term_id
         ORDER BY last_updated DESC NULLS LAST, term_id DESC, name
         """
-        cur.execute(sql, (user,))
+        cur.execute(sql, (user, REGISTERED_PLAN_NAME))
         rows = cur.fetchall()
 
         return {

--- a/Backend/services/plan_service.py
+++ b/Backend/services/plan_service.py
@@ -12,7 +12,7 @@ def save_courses_to_plan(course_ids, user, term, name):
         cur.execute(delete_sql, (user, term, name))
 
         for course_id in course_ids:
-            sql = "INSERT INTO plan(student_id, course_id, term_id, name, is_active) VALUES (%s, %s, %s, %s, %s)"
+            sql = "INSERT INTO plan(student_id, course_id, term_id, name, is_active, updated_at) VALUES (%s, %s, %s, %s, %s, NOW())"
             cur.execute(sql, (user, course_id, term, name, True))
 
         conn.commit()
@@ -150,12 +150,13 @@ def list_student_plans(user: str):
         cur = conn.cursor()
 
         sql = """
-        SELECT DISTINCT name, term_id,
-               COUNT(course_id) AS course_count
+        SELECT name, term_id,
+               COUNT(course_id) AS course_count,
+               MAX(updated_at) AS last_updated
         FROM plan
         WHERE student_id = %s
         GROUP BY name, term_id
-        ORDER BY term_id DESC, name
+        ORDER BY last_updated DESC NULLS LAST, term_id DESC, name
         """
         cur.execute(sql, (user,))
         rows = cur.fetchall()

--- a/Backend/services/plan_service.py
+++ b/Backend/services/plan_service.py
@@ -143,3 +143,34 @@ def load_plans_from_user(user: str):
         raise
     finally:
         conn.close()
+
+
+def list_student_plans(user: str):
+    conn = get_conn()
+    try:
+        cur = conn.cursor()
+
+        sql = """
+        SELECT DISTINCT name, term_id,
+               COUNT(course_id) AS course_count
+        FROM plan
+        WHERE student_id = %s
+        GROUP BY name, term_id
+        ORDER BY term_id DESC, name
+        """
+        cur.execute(sql, (user,))
+        rows = cur.fetchall()
+
+        return {
+            "plans": [
+                {
+                    "name": r["name"],
+                    "termId": r["term_id"],
+                    "courseCount": r["course_count"],
+                }
+                for r in rows
+            ]
+        }
+
+    finally:
+        conn.close()

--- a/Backend/services/plan_service.py
+++ b/Backend/services/plan_service.py
@@ -1,3 +1,4 @@
+from fastapi import HTTPException
 from Backend.db import get_conn
 from Backend.routers.courses import days_str, format_location, format_time_range
 
@@ -16,10 +17,14 @@ def save_courses_to_plan(course_ids, user, term, name):
 
         conn.commit()
 
+    except Exception as e:
+        conn.rollback()
+        raise HTTPException(status_code=500, detail=f"Failed to save plan: {e}")
+
     finally:
         conn.close()
 
-    return {"received": course_ids}
+    return {"success": True, "received": course_ids}
 
 def load_courses_from_plan(user: str, term: int, name: str):
 

--- a/Backend/services/plan_service.py
+++ b/Backend/services/plan_service.py
@@ -68,11 +68,10 @@ def load_courses_from_plan(user: str, term: int, name: str):
         JOIN course c ON c.id = s.course_id
         LEFT JOIN time_slot t ON t.id = c.id
         WHERE c.id = ANY(%s)
-          AND s.term_id = %s
         ORDER BY c.subject, c.course_number
         """
 
-        cur.execute(sql, (course_ids, term))
+        cur.execute(sql, (course_ids,))
         rows = cur.fetchall()
 
     finally:

--- a/Frontend/src/components/AdminOverride/AdminOverride.jsx
+++ b/Frontend/src/components/AdminOverride/AdminOverride.jsx
@@ -1,0 +1,301 @@
+import { useState, useMemo } from "react";
+import CourseSearch from "../CourseSearch/CourseSearch";
+import WeeklySchedule from "../WeeklySchedule/WeeklySchedule";
+import { detectConflicts } from "../../utils/courseUtils";
+
+const TERM_OPTIONS = [
+  { label: "Spring/Summer 2026", value: 202601 },
+  { label: "Fall 2026", value: 202609 },
+];
+
+function normalizeCourse(raw) {
+  return {
+    ...raw,
+    number: raw.courseNumber ?? raw.number ?? "",
+    meetingDays: raw.days ?? raw.meetingDays ?? "TBA",
+    meetingTime: raw.time ?? raw.meetingTime ?? "TBA",
+  };
+}
+
+export default function AdminOverride({ onClose }) {
+  const adminUser = localStorage.getItem("username") || "";
+
+  const [studentId, setStudentId] = useState("");
+  const [termId, setTermId] = useState("");
+  const [planName, setPlanName] = useState("");
+
+  const [courses, setCourses] = useState([]);
+  const [loadStatus, setLoadStatus] = useState("");
+  const [loadLoading, setLoadLoading] = useState(false);
+
+  const [saveStatus, setSaveStatus] = useState("");
+  const [saveLoading, setSaveLoading] = useState(false);
+
+  const [planLoaded, setPlanLoaded] = useState(false);
+
+  const totalCredits = courses.reduce((sum, c) => sum + (c.credits || 0), 0);
+  const conflicts = useMemo(() => detectConflicts(courses), [courses]);
+
+  const handleLoadPlan = async () => {
+    if (!studentId.trim()) { setLoadStatus("Enter a Student ID."); return; }
+    if (!termId) { setLoadStatus("Select a term."); return; }
+    if (!planName.trim()) { setLoadStatus("Enter a plan name."); return; }
+
+    setLoadLoading(true);
+    setLoadStatus("");
+    setSaveStatus("");
+    try {
+      const params = new URLSearchParams({
+        admin_user: adminUser,
+        student_id: studentId.trim(),
+        term: termId,
+        name: planName.trim(),
+      });
+      const res = await fetch(`/api/admin/plans/load?${params}`);
+      if (!res.ok) {
+        const err = await res.json().catch(() => null);
+        throw new Error(err?.detail || `Server error: ${res.status}`);
+      }
+      const data = await res.json();
+      const loaded = (data.results ?? []).map(normalizeCourse);
+      setCourses(loaded);
+      setPlanLoaded(true);
+      setLoadStatus(
+        loaded.length > 0
+          ? `Loaded ${loaded.length} course(s) for ${studentId.trim()}.`
+          : `No saved plan found. You can add courses below.`
+      );
+    } catch (err) {
+      setLoadStatus(err.message || "Failed to load plan.");
+      setPlanLoaded(false);
+    } finally {
+      setLoadLoading(false);
+    }
+  };
+
+  const handleAddCourse = (course) => {
+    setCourses((prev) => [...prev, course]);
+    setSaveStatus("");
+  };
+
+  const handleRemoveCourse = (course) => {
+    setCourses((prev) => prev.filter((c) => c.crn !== course.crn));
+    setSaveStatus("");
+  };
+
+  const handleForceSave = async () => {
+    if (!studentId.trim() || !termId || !planName.trim()) {
+      setSaveStatus("Student ID, term, and plan name are required.");
+      return;
+    }
+
+    setSaveLoading(true);
+    setSaveStatus("");
+    try {
+      const courseIds = courses.map((c) => c.courseId).filter(Boolean);
+      const res = await fetch("/api/admin/plans/save", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          admin_user: adminUser,
+          student_id: studentId.trim(),
+          course_ids: courseIds,
+          term: parseInt(termId),
+          name: planName.trim(),
+        }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => null);
+        throw new Error(err?.detail || `Server error: ${res.status}`);
+      }
+      setSaveStatus("Plan saved successfully!");
+    } catch (err) {
+      setSaveStatus(err.message || "Failed to save plan.");
+    } finally {
+      setSaveLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col bg-[#f0f4f3]">
+      {/* Header */}
+      <header className="bg-[#7c2d12] border-b border-[#9a3412] shadow-md flex-shrink-0">
+        <div className="flex items-center justify-between px-6 h-[56px]">
+          <div className="flex items-center gap-3">
+            <span className="text-white text-sm font-semibold bg-red-600 px-2 py-0.5 rounded">
+              ADMIN
+            </span>
+            <h1 className="text-white text-base font-semibold">
+              Schedule Override
+            </h1>
+          </div>
+          <button
+            onClick={onClose}
+            className="px-3 py-1.5 text-xs font-medium text-white bg-white/20 border border-white/30 rounded-md hover:bg-white/30 transition"
+          >
+            Close
+          </button>
+        </div>
+      </header>
+
+      {/* Student lookup bar */}
+      <div className="bg-white border-b border-[#e2e8f0] px-6 py-4 flex-shrink-0">
+        <div className="flex flex-wrap items-end gap-3">
+          <div className="flex flex-col gap-1">
+            <label className="text-xs font-medium text-[#64748b]">Student ID</label>
+            <input
+              type="text"
+              placeholder="e.g. john_doe"
+              value={studentId}
+              onChange={(e) => setStudentId(e.target.value)}
+              className="w-44 px-3 py-2 border border-[#e2e8f0] rounded-md text-sm text-[#334155] outline-none focus:border-[#7c2d12] focus:ring-2 focus:ring-[#7c2d12]/10 transition"
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-xs font-medium text-[#64748b]">Term</label>
+            <select
+              value={termId}
+              onChange={(e) => setTermId(e.target.value)}
+              className="w-52 px-3 py-2 border border-[#e2e8f0] rounded-md text-sm text-[#334155] bg-white outline-none focus:border-[#7c2d12] focus:ring-2 focus:ring-[#7c2d12]/10 transition"
+            >
+              <option value="">Select term</option>
+              {TERM_OPTIONS.map((t) => (
+                <option key={t.value} value={t.value}>{t.label}</option>
+              ))}
+            </select>
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-xs font-medium text-[#64748b]">Plan Name</label>
+            <input
+              type="text"
+              placeholder="e.g. Fall Plan"
+              value={planName}
+              onChange={(e) => setPlanName(e.target.value)}
+              className="w-44 px-3 py-2 border border-[#e2e8f0] rounded-md text-sm text-[#334155] outline-none focus:border-[#7c2d12] focus:ring-2 focus:ring-[#7c2d12]/10 transition"
+            />
+          </div>
+          <button
+            onClick={handleLoadPlan}
+            disabled={loadLoading}
+            className="px-4 py-2 bg-[#7c2d12] hover:bg-[#6b2710] disabled:opacity-50 text-white text-sm font-medium rounded-md transition"
+          >
+            {loadLoading ? "Loading…" : "Load Plan"}
+          </button>
+
+          {loadStatus && (
+            <p className={`text-sm px-3 py-2 rounded self-end ${
+              loadStatus.startsWith("Loaded") || loadStatus.startsWith("No saved")
+                ? "bg-green-50 text-green-700 border border-green-200"
+                : "bg-red-50 text-red-600 border border-red-200"
+            }`}>
+              {loadStatus}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Main content */}
+      {planLoaded && (
+        <main className="flex-1 flex gap-4 px-4 sm:px-6 py-4 min-h-0 overflow-hidden">
+          {/* Left: Course search */}
+          <div className="w-[55%] flex-shrink-0 overflow-y-auto">
+            <CourseSearch
+              registered={courses}
+              onAddCourse={handleAddCourse}
+              onRemoveCourse={handleRemoveCourse}
+              conflicts={conflicts}
+              bypassCreditLimit
+            />
+          </div>
+
+          {/* Right: Student schedule + save */}
+          <div
+            className="flex-1 flex flex-col gap-4 overflow-y-auto"
+            style={{ maxHeight: "calc(100vh - 56px - 80px - 2rem)" }}
+          >
+            {/* Schedule summary */}
+            <div className="bg-white border border-[#e2e8f0] rounded-lg shadow-sm p-4">
+              <div className="flex items-center justify-between mb-3">
+                <h2 className="text-base font-semibold text-[#1e293b]">
+                  {studentId.trim()}'s Schedule
+                </h2>
+                <div className="flex items-center gap-2">
+                  <span
+                    className={`text-xs font-medium px-2 py-0.5 rounded ${
+                      totalCredits > 18
+                        ? "bg-amber-100 text-amber-800 border border-amber-300"
+                        : "bg-[#d1fae5] text-[#065f46]"
+                    }`}
+                  >
+                    {totalCredits} credits
+                    {totalCredits > 18 && " (override)"}
+                  </span>
+                </div>
+              </div>
+
+              {courses.length === 0 ? (
+                <p className="text-sm text-[#94a3b8] text-center py-4">
+                  No courses in this plan. Use search to add courses.
+                </p>
+              ) : (
+                <ul className="flex flex-col gap-2">
+                  {courses.map((course) => (
+                    <li
+                      key={course.crn}
+                      className="flex items-center justify-between gap-2 p-2.5 bg-[#f8fafc] border border-[#e2e8f0] rounded-md"
+                    >
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium text-[#1e293b] break-words whitespace-normal">
+                          {course.name}
+                        </p>
+                        <p className="text-xs text-[#64748b] break-words whitespace-normal">
+                          {course.courseCode} · {course.credits} cr · {course.meetingDays} {course.meetingTime}
+                        </p>
+                      </div>
+                      <button
+                        onClick={() => handleRemoveCourse(course)}
+                        className="flex-shrink-0 px-2 py-1 text-xs text-red-600 border border-red-200 rounded hover:bg-red-50 transition"
+                      >
+                        Remove
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+
+              {/* Force save */}
+              <div className="mt-4 flex items-center gap-3">
+                <button
+                  onClick={handleForceSave}
+                  disabled={saveLoading || courses.length === 0}
+                  className="px-4 py-2 bg-[#7c2d12] hover:bg-[#6b2710] disabled:opacity-50 text-white text-sm font-medium rounded-md transition"
+                >
+                  {saveLoading ? "Saving…" : "Force Save"}
+                </button>
+                {totalCredits > 18 && (
+                  <span className="text-xs text-amber-700 bg-amber-50 border border-amber-200 px-2 py-1 rounded">
+                    Exceeds 18 credit limit — admin override active
+                  </span>
+                )}
+                {saveStatus && (
+                  <p className={`text-sm px-3 py-1.5 rounded ${
+                    saveStatus.includes("success")
+                      ? "bg-green-50 text-green-700 border border-green-200"
+                      : "bg-red-50 text-red-600 border border-red-200"
+                  }`}>
+                    {saveStatus}
+                  </p>
+                )}
+              </div>
+            </div>
+
+            {/* Weekly schedule view */}
+            <div className="flex-1 min-h-0">
+              <WeeklySchedule registered={courses} conflicts={conflicts} />
+            </div>
+          </div>
+        </main>
+      )}
+    </div>
+  );
+}

--- a/Frontend/src/components/CourseSearch/CourseSearch.jsx
+++ b/Frontend/src/components/CourseSearch/CourseSearch.jsx
@@ -37,7 +37,7 @@ function sortResults(results, sortBy, sortOrder) {
   });
 }
 
-export default function CourseSearch({ registered = [], onAddCourse, onRemoveCourse, conflicts = new Set() }) {
+export default function CourseSearch({ registered = [], onAddCourse, onRemoveCourse, conflicts = new Set(), bypassCreditLimit = false }) {
   const [courseSubject, setCourseSubject] = useState("");
   const [courseNumber, setCourseNumber] = useState("");
   const [crnSearch, setCrnSearch] = useState("");
@@ -112,7 +112,7 @@ export default function CourseSearch({ registered = [], onAddCourse, onRemoveCou
       onRemoveCourse?.(course);
       return;
     }
-    if (totalCredits + (course.credits || 0) > 18) {
+    if (!bypassCreditLimit && totalCredits + (course.credits || 0) > 18) {
       setErrorMessage("Error: Cannot exceed 18 credits.");
       return;
     }

--- a/Frontend/src/components/MySchedule/MySchedule.jsx
+++ b/Frontend/src/components/MySchedule/MySchedule.jsx
@@ -1,40 +1,19 @@
 import { forwardRef } from "react";
 
-function MySchedule({ courses, onRemove, totalCredits, onSave, saveStatus }, ref) {
+function MySchedule({ courses, onRemove, totalCredits }, ref) {
   return (
     <div ref={ref} className="bg-white border border-[#e2e8f0] rounded-lg shadow-sm p-4">
       <div className="flex items-center justify-between mb-3">
         <h2 className="text-base font-semibold text-[#1e293b]">My Schedule</h2>
-        <div className="flex items-center gap-2">
-          <span
-            className={`text-xs font-medium px-2 py-0.5 rounded ${
-              totalCredits >= 18
-                ? "bg-red-100 text-red-700"
-                : "bg-[#d1fae5] text-[#065f46]"
-            }`}
-          >
-            {totalCredits} / 18 credits
-          </span>
-          <button
-            onClick={onSave}
-            disabled={saveStatus === "saving" || courses.length === 0}
-            className={`text-xs font-medium px-3 py-1 rounded transition ${
-              saveStatus === "saved"
-                ? "bg-[#d1fae5] text-[#065f46] border border-[#6ee7b7]"
-                : saveStatus === "error"
-                ? "bg-red-100 text-red-700 border border-red-300"
-                : "bg-[#0F3B2E] hover:bg-[#0a2a20] text-white disabled:opacity-40"
-            }`}
-          >
-            {saveStatus === "saving"
-              ? "Saving..."
-              : saveStatus === "saved"
-              ? "Saved ✓"
-              : saveStatus === "error"
-              ? "Save Failed"
-              : "Save"}
-          </button>
-        </div>
+        <span
+          className={`text-xs font-medium px-2 py-0.5 rounded ${
+            totalCredits >= 18
+              ? "bg-red-100 text-red-700"
+              : "bg-[#d1fae5] text-[#065f46]"
+          }`}
+        >
+          {totalCredits} / 18 credits
+        </span>
       </div>
 
       {courses.length === 0 ? (

--- a/Frontend/src/pages/AdminPage/AdminPage.jsx
+++ b/Frontend/src/pages/AdminPage/AdminPage.jsx
@@ -5,15 +5,6 @@ import WeeklySchedule from "../../components/WeeklySchedule/WeeklySchedule";
 import { detectConflicts } from "../../utils/courseUtils";
 import wayneLogo from "../../assets/images/wayneLogo.png";
 
-const TERM_OPTIONS = [
-  { label: "Spring/Summer 2026", value: 202601 },
-  { label: "Fall 2026", value: 202609 },
-];
-
-function termLabel(termId) {
-  return TERM_OPTIONS.find((t) => t.value === termId)?.label ?? String(termId);
-}
-
 function normalizePlanCourse(c) {
   return {
     ...c,
@@ -30,15 +21,10 @@ function AdminPage() {
   const userRole = localStorage.getItem("userRole") || "";
 
   const [studentId, setStudentId] = useState("");
-  const [plans, setPlans] = useState([]);
-  const [plansLoading, setPlansLoading] = useState(false);
-  const [plansError, setPlansError] = useState("");
-  const [plansSearched, setPlansSearched] = useState(false);
-
-  const [activePlan, setActivePlan] = useState(null);
   const [courses, setCourses] = useState([]);
-  const [loadLoading, setLoadLoading] = useState(false);
-  const [loadError, setLoadError] = useState("");
+  const [searchLoading, setSearchLoading] = useState(false);
+  const [searchError, setSearchError] = useState("");
+  const [searched, setSearched] = useState(false);
 
   const [saveStatus, setSaveStatus] = useState("");
   const [saveLoading, setSaveLoading] = useState(false);
@@ -59,16 +45,14 @@ function AdminPage() {
     [courses]
   );
 
-  const handleSearchPlans = async () => {
+  const handleSearchRegistered = async () => {
     const sid = studentId.trim();
-    if (!sid) { setPlansError("Enter a Student ID."); return; }
+    if (!sid) { setSearchError("Enter a Student ID."); return; }
 
-    setPlansLoading(true);
-    setPlansError("");
-    setPlansSearched(true);
-    setActivePlan(null);
+    setSearchLoading(true);
+    setSearchError("");
+    setSearched(true);
     setCourses([]);
-    setLoadError("");
     setSaveStatus("");
 
     try {
@@ -76,35 +60,7 @@ function AdminPage() {
         admin_user: username,
         student_id: sid,
       });
-      const res = await fetch(`/api/admin/plans/list?${params}`);
-      if (!res.ok) {
-        const err = await res.json().catch(() => null);
-        throw new Error(err?.detail || `Server error: ${res.status}`);
-      }
-      const data = await res.json();
-      setPlans(data.plans ?? []);
-    } catch (err) {
-      setPlansError(err.message || "Failed to fetch plans.");
-      setPlans([]);
-    } finally {
-      setPlansLoading(false);
-    }
-  };
-
-  const handleSelectPlan = async (plan) => {
-    setActivePlan(plan);
-    setLoadLoading(true);
-    setLoadError("");
-    setSaveStatus("");
-
-    try {
-      const params = new URLSearchParams({
-        admin_user: username,
-        student_id: studentId.trim(),
-        term: String(plan.termId),
-        name: plan.name,
-      });
-      const res = await fetch(`/api/admin/plans/load?${params}`);
+      const res = await fetch(`/api/admin/plans/registered?${params}`);
       if (!res.ok) {
         const err = await res.json().catch(() => null);
         throw new Error(err?.detail || `Server error: ${res.status}`);
@@ -112,10 +68,10 @@ function AdminPage() {
       const data = await res.json();
       setCourses((data.results ?? []).map(normalizePlanCourse));
     } catch (err) {
-      setLoadError(err.message || "Failed to load plan.");
+      setSearchError(err.message || "Failed to load registered schedule.");
       setCourses([]);
     } finally {
-      setLoadLoading(false);
+      setSearchLoading(false);
     }
   };
 
@@ -130,29 +86,26 @@ function AdminPage() {
   };
 
   const handleForceSave = async () => {
-    if (!activePlan) return;
     setSaveLoading(true);
     setSaveStatus("");
     try {
       const courseIds = courses.map((c) => c.courseId).filter(Boolean);
-      const res = await fetch("/api/admin/plans/save", {
+      const res = await fetch("/api/admin/plans/register", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           admin_user: username,
           student_id: studentId.trim(),
           course_ids: courseIds,
-          term: activePlan.termId,
-          name: activePlan.name,
         }),
       });
       if (!res.ok) {
         const err = await res.json().catch(() => null);
         throw new Error(err?.detail || `Server error: ${res.status}`);
       }
-      setSaveStatus("Plan saved successfully!");
+      setSaveStatus("Registered schedule updated!");
     } catch (err) {
-      setSaveStatus(err.message || "Failed to save plan.");
+      setSaveStatus(err.message || "Failed to update registered schedule.");
     } finally {
       setSaveLoading(false);
     }
@@ -212,7 +165,7 @@ function AdminPage() {
             Look up a student
           </h2>
           <p className="text-sm text-[#64748b] mb-5">
-            Enter a student ID to see all their saved plans.
+            Enter a student ID to view and edit their registered schedule.
           </p>
 
           <div className="flex flex-col gap-4 sm:flex-row sm:flex-wrap sm:items-end">
@@ -225,119 +178,69 @@ function AdminPage() {
                 type="text"
                 value={studentId}
                 onChange={(e) => setStudentId(e.target.value)}
-                onKeyDown={(e) => e.key === "Enter" && handleSearchPlans()}
+                onKeyDown={(e) => e.key === "Enter" && handleSearchRegistered()}
                 placeholder="e.g. student1"
                 className="w-full px-3 py-2 border border-[#e2e8f0] rounded-md text-sm text-[#334155] outline-none focus:border-[#0F3B2E] focus:ring-2 focus:ring-[#0F3B2E]/10"
                 autoComplete="off"
               />
             </div>
             <button
-              onClick={handleSearchPlans}
-              disabled={plansLoading}
+              onClick={handleSearchRegistered}
+              disabled={searchLoading}
               className="px-5 py-2 bg-[#0F3B2E] hover:bg-[#0a2a20] disabled:opacity-50 text-white text-sm font-semibold rounded-md transition"
             >
-              {plansLoading ? "Searching…" : "Search"}
+              {searchLoading ? "Loading…" : "Search"}
             </button>
           </div>
 
-          {plansError && (
+          {searchError && (
             <p className="mt-4 px-3 py-2 bg-red-50 border border-red-200 rounded text-sm text-red-700">
-              {plansError}
+              {searchError}
             </p>
-          )}
-
-          {/* Plan list */}
-          {plansSearched && !plansLoading && !plansError && (
-            <div className="mt-5">
-              {plans.length === 0 ? (
-                <p className="text-sm text-[#94a3b8]">
-                  No saved plans found for <strong>{studentId.trim()}</strong>.
-                </p>
-              ) : (
-                <>
-                  <p className="text-xs font-medium text-[#64748b] uppercase tracking-wide mb-2">
-                    {plans.length} plan{plans.length !== 1 ? "s" : ""} found — click to load
-                  </p>
-                  <div className="flex flex-col gap-2">
-                    {plans.map((p, i) => {
-                      const isActive =
-                        activePlan?.name === p.name &&
-                        activePlan?.termId === p.termId;
-                      return (
-                        <button
-                          key={`${p.name}-${p.termId}-${i}`}
-                          onClick={() => handleSelectPlan(p)}
-                          className={`text-left px-4 py-3 rounded-lg border transition ${
-                            isActive
-                              ? "bg-[#0F3B2E] text-white border-[#0F3B2E]"
-                              : "bg-[#f8fafc] text-[#334155] border-[#e2e8f0] hover:border-[#0F3B2E] hover:bg-[#f0fdf4]"
-                          }`}
-                        >
-                          <span className="text-sm font-semibold">{p.name}</span>
-                          <span className={`ml-3 text-xs ${isActive ? "text-[#a7d9cc]" : "text-[#64748b]"}`}>
-                            {termLabel(p.termId)} · {p.courseCount} course{p.courseCount !== 1 ? "s" : ""}
-                          </span>
-                        </button>
-                      );
-                    })}
-                  </div>
-                </>
-              )}
-            </div>
           )}
         </section>
 
-        {/* Step 2: Loaded plan editor */}
-        {activePlan && (
+        {/* Registered schedule editor */}
+        {searched && !searchLoading && !searchError && (
           <>
-            {loadLoading ? (
-              <div className="bg-white border border-[#e2e8f0] rounded-lg p-12 flex items-center justify-center text-[#64748b] text-sm mb-6">
-                Loading schedule…
+            {/* Info bar */}
+            <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+              <div className="flex items-baseline gap-2">
+                <h2 className="text-lg font-semibold text-[#1e293b]">
+                  {studentId.trim()}'s Registered Schedule
+                </h2>
+                {courses.length === 0 && (
+                  <span className="text-sm text-[#94a3b8]">— no registered courses</span>
+                )}
               </div>
-            ) : loadError ? (
-              <div className="bg-red-50 border border-red-200 rounded-lg px-4 py-3 text-sm text-red-700 mb-6">
-                {loadError}
+              <div className="flex items-center gap-3">
+                <span
+                  className={`text-xs font-medium px-2 py-0.5 rounded ${
+                    totalCredits > 18
+                      ? "bg-amber-100 text-amber-800 border border-amber-300"
+                      : "bg-[#d1fae5] text-[#065f46]"
+                  }`}
+                >
+                  {totalCredits} credits{totalCredits > 18 ? " (override)" : ""}
+                </span>
+                <button
+                  onClick={handleForceSave}
+                  disabled={saveLoading || courses.length === 0}
+                  className="px-4 py-1.5 bg-[#7c2d12] hover:bg-[#6b2710] disabled:opacity-50 text-white text-sm font-medium rounded-md transition"
+                >
+                  {saveLoading ? "Saving…" : "Force Save"}
+                </button>
+                {saveStatus && (
+                  <p className={`text-sm px-3 py-1.5 rounded ${
+                    saveStatus.includes("updated") || saveStatus.includes("success")
+                      ? "bg-green-50 text-green-700 border border-green-200"
+                      : "bg-red-50 text-red-600 border border-red-200"
+                  }`}>
+                    {saveStatus}
+                  </p>
+                )}
               </div>
-            ) : (
-              <>
-                {/* Info bar */}
-                <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
-                  <div className="flex items-baseline gap-2">
-                    <h2 className="text-lg font-semibold text-[#1e293b]">
-                      {studentId.trim()}'s Schedule
-                    </h2>
-                    <span className="text-sm text-[#64748b]">
-                      {activePlan.name} · {termLabel(activePlan.termId)}
-                    </span>
-                  </div>
-                  <div className="flex items-center gap-3">
-                    <span
-                      className={`text-xs font-medium px-2 py-0.5 rounded ${
-                        totalCredits > 18
-                          ? "bg-amber-100 text-amber-800 border border-amber-300"
-                          : "bg-[#d1fae5] text-[#065f46]"
-                      }`}
-                    >
-                      {totalCredits} credits{totalCredits > 18 ? " (override)" : ""}
-                    </span>
-                    <button
-                      onClick={handleForceSave}
-                      disabled={saveLoading || courses.length === 0}
-                      className="px-4 py-1.5 bg-[#7c2d12] hover:bg-[#6b2710] disabled:opacity-50 text-white text-sm font-medium rounded-md transition"
-                    >
-                      {saveLoading ? "Saving…" : "Force Save"}
-                    </button>
-                    {saveStatus && (
-                      <p className={`text-sm px-3 py-1.5 rounded ${
-                        saveStatus.includes("success")
-                          ? "bg-green-50 text-green-700 border border-green-200"
-                          : "bg-red-50 text-red-600 border border-red-200"
-                      }`}>
-                        {saveStatus}
-                      </p>
-                    )}
-                  </div>
-                </div>
+            </div>
 
                 {/* Main two-panel layout */}
                 <div className="flex gap-4">
@@ -393,8 +296,6 @@ function AdminPage() {
                     </div>
                   </div>
                 </div>
-              </>
-            )}
           </>
         )}
       </main>

--- a/Frontend/src/pages/AdminPage/AdminPage.jsx
+++ b/Frontend/src/pages/AdminPage/AdminPage.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import CourseSearch from "../../components/CourseSearch/CourseSearch";
 import WeeklySchedule from "../../components/WeeklySchedule/WeeklySchedule";
 import { detectConflicts } from "../../utils/courseUtils";
 import wayneLogo from "../../assets/images/wayneLogo.png";
@@ -9,21 +10,16 @@ const TERM_OPTIONS = [
   { label: "Fall 2026", value: 202609 },
 ];
 
+function termLabel(termId) {
+  return TERM_OPTIONS.find((t) => t.value === termId)?.label ?? String(termId);
+}
+
 function normalizePlanCourse(c) {
-  const timeRaw = c.time || "";
-  let meetingTime = "TBA";
-  if (timeRaw && timeRaw !== "TBA") {
-    const first = timeRaw.split(" - ")[0]?.trim();
-    if (first) meetingTime = first;
-  }
-  const loc = c.location;
-  const building = loc && loc !== "TBA" ? loc : "";
   return {
     ...c,
-    meetingDays: c.days || "TBA",
-    meetingTime,
-    building,
-    room: "",
+    number: c.courseNumber ?? c.number ?? "",
+    meetingDays: c.meetingDays ?? c.days ?? "TBA",
+    meetingTime: c.meetingTime ?? c.time ?? "TBA",
   };
 }
 
@@ -34,11 +30,18 @@ function AdminPage() {
   const userRole = localStorage.getItem("userRole") || "";
 
   const [studentId, setStudentId] = useState("");
-  const [termId, setTermId] = useState(String(TERM_OPTIONS[0].value));
-  const [planName, setPlanName] = useState("");
+  const [plans, setPlans] = useState([]);
+  const [plansLoading, setPlansLoading] = useState(false);
+  const [plansError, setPlansError] = useState("");
+  const [plansSearched, setPlansSearched] = useState(false);
+
+  const [activePlan, setActivePlan] = useState(null);
+  const [courses, setCourses] = useState([]);
+  const [loadLoading, setLoadLoading] = useState(false);
   const [loadError, setLoadError] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [rawResults, setRawResults] = useState(null);
+
+  const [saveStatus, setSaveStatus] = useState("");
+  const [saveLoading, setSaveLoading] = useState(false);
 
   useEffect(() => {
     if (!isLoggedIn) {
@@ -50,66 +53,108 @@ function AdminPage() {
     }
   }, [isLoggedIn, userRole, navigate]);
 
-  const registered = useMemo(() => {
-    if (!rawResults) return [];
-    return rawResults.map(normalizePlanCourse);
-  }, [rawResults]);
-
-  const conflicts = useMemo(
-    () => detectConflicts(registered),
-    [registered]
-  );
-
+  const conflicts = useMemo(() => detectConflicts(courses), [courses]);
   const totalCredits = useMemo(
-    () => registered.reduce((s, c) => s + (c.credits || 0), 0),
-    [registered]
+    () => courses.reduce((s, c) => s + (c.credits || 0), 0),
+    [courses]
   );
 
-  const handleLoadSchedule = async (e) => {
-    e.preventDefault();
-    setLoadError("");
+  const handleSearchPlans = async () => {
     const sid = studentId.trim();
-    const pname = planName.trim();
-    if (!sid || !pname) {
-      setLoadError("Student ID and plan name are required.");
-      return;
-    }
-    const term = Number(termId);
-    if (!Number.isFinite(term)) {
-      setLoadError("Select a valid term.");
-      return;
-    }
+    if (!sid) { setPlansError("Enter a Student ID."); return; }
 
-    setLoading(true);
+    setPlansLoading(true);
+    setPlansError("");
+    setPlansSearched(true);
+    setActivePlan(null);
+    setCourses([]);
+    setLoadError("");
+    setSaveStatus("");
+
     try {
       const params = new URLSearchParams({
         admin_user: username,
         student_id: sid,
-        term: String(term),
-        name: pname,
+      });
+      const res = await fetch(`/api/admin/plans/list?${params}`);
+      if (!res.ok) {
+        const err = await res.json().catch(() => null);
+        throw new Error(err?.detail || `Server error: ${res.status}`);
+      }
+      const data = await res.json();
+      setPlans(data.plans ?? []);
+    } catch (err) {
+      setPlansError(err.message || "Failed to fetch plans.");
+      setPlans([]);
+    } finally {
+      setPlansLoading(false);
+    }
+  };
+
+  const handleSelectPlan = async (plan) => {
+    setActivePlan(plan);
+    setLoadLoading(true);
+    setLoadError("");
+    setSaveStatus("");
+
+    try {
+      const params = new URLSearchParams({
+        admin_user: username,
+        student_id: studentId.trim(),
+        term: String(plan.termId),
+        name: plan.name,
       });
       const res = await fetch(`/api/admin/plans/load?${params}`);
-      const data = await res.json().catch(() => ({}));
-
       if (!res.ok) {
-        const detail =
-          typeof data.detail === "string"
-            ? data.detail
-            : Array.isArray(data.detail)
-              ? data.detail.map((d) => d.msg || d).join(" ")
-              : res.statusText;
-        setRawResults(null);
-        setLoadError(detail || "Could not load this plan.");
-        return;
+        const err = await res.json().catch(() => null);
+        throw new Error(err?.detail || `Server error: ${res.status}`);
       }
-
-      const list = data.results ?? [];
-      setRawResults(list);
-    } catch {
-      setRawResults(null);
-      setLoadError("Unable to reach the server. Please try again.");
+      const data = await res.json();
+      setCourses((data.results ?? []).map(normalizePlanCourse));
+    } catch (err) {
+      setLoadError(err.message || "Failed to load plan.");
+      setCourses([]);
     } finally {
-      setLoading(false);
+      setLoadLoading(false);
+    }
+  };
+
+  const handleAddCourse = (course) => {
+    setCourses((prev) => [...prev, course]);
+    setSaveStatus("");
+  };
+
+  const handleRemoveCourse = (course) => {
+    setCourses((prev) => prev.filter((c) => c.crn !== course.crn));
+    setSaveStatus("");
+  };
+
+  const handleForceSave = async () => {
+    if (!activePlan) return;
+    setSaveLoading(true);
+    setSaveStatus("");
+    try {
+      const courseIds = courses.map((c) => c.courseId).filter(Boolean);
+      const res = await fetch("/api/admin/plans/save", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          admin_user: username,
+          student_id: studentId.trim(),
+          course_ids: courseIds,
+          term: activePlan.termId,
+          name: activePlan.name,
+        }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => null);
+        throw new Error(err?.detail || `Server error: ${res.status}`);
+      }
+      setSaveStatus("Plan saved successfully!");
+    } catch (err) {
+      setSaveStatus(err.message || "Failed to save plan.");
+    } finally {
+      setSaveLoading(false);
     }
   };
 
@@ -161,20 +206,17 @@ function AdminPage() {
           <span className="font-medium text-[#334155]">{username}</span>
         </p>
 
-        <section className="bg-white border border-[#e2e8f0] rounded-lg shadow-sm p-6 mb-8">
+        {/* Step 1: Search student */}
+        <section className="bg-white border border-[#e2e8f0] rounded-lg shadow-sm p-6 mb-6">
           <h2 className="text-lg font-semibold text-[#1e293b] mb-1">
-            Look up a student schedule
+            Look up a student
           </h2>
           <p className="text-sm text-[#64748b] mb-5">
-            Load the saved plan for a student by ID, term, and plan name (same
-            fields as in the database).
+            Enter a student ID to see all their saved plans.
           </p>
 
-          <form
-            onSubmit={handleLoadSchedule}
-            className="flex flex-col gap-4 sm:flex-row sm:flex-wrap sm:items-end"
-          >
-            <div className="flex-1 min-w-[10rem]">
+          <div className="flex items-end gap-3">
+            <div className="flex-1 max-w-xs">
               <label className="block text-xs font-medium text-[#64748b] mb-1">
                 Student ID
               </label>
@@ -182,105 +224,178 @@ function AdminPage() {
                 type="text"
                 value={studentId}
                 onChange={(e) => setStudentId(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && handleSearchPlans()}
                 placeholder="e.g. student1"
                 className="w-full px-3 py-2 border border-[#e2e8f0] rounded-md text-sm text-[#334155] outline-none focus:border-[#0F3B2E] focus:ring-2 focus:ring-[#0F3B2E]/10"
                 autoComplete="off"
               />
             </div>
-            <div className="w-full sm:w-48">
-              <label className="block text-xs font-medium text-[#64748b] mb-1">
-                Term
-              </label>
-              <select
-                value={termId}
-                onChange={(e) => setTermId(e.target.value)}
-                className="w-full px-3 py-2 border border-[#e2e8f0] rounded-md text-sm text-[#334155] bg-white outline-none focus:border-[#0F3B2E] focus:ring-2 focus:ring-[#0F3B2E]/10"
-              >
-                {TERM_OPTIONS.map((t) => (
-                  <option key={t.value} value={t.value}>
-                    {t.label}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <div className="flex-1 min-w-[10rem]">
-              <label className="block text-xs font-medium text-[#64748b] mb-1">
-                Plan name
-              </label>
-              <input
-                type="text"
-                value={planName}
-                onChange={(e) => setPlanName(e.target.value)}
-                placeholder="Saved plan name"
-                className="w-full px-3 py-2 border border-[#e2e8f0] rounded-md text-sm text-[#334155] outline-none focus:border-[#0F3B2E] focus:ring-2 focus:ring-[#0F3B2E]/10"
-                autoComplete="off"
-              />
-            </div>
             <button
-              type="submit"
-              disabled={loading}
-              className="px-5 py-2 bg-[#0F3B2E] hover:bg-[#0a2a20] disabled:opacity-50 text-white text-sm font-semibold rounded-md transition w-full sm:w-auto"
+              onClick={handleSearchPlans}
+              disabled={plansLoading}
+              className="px-5 py-2 bg-[#0F3B2E] hover:bg-[#0a2a20] disabled:opacity-50 text-white text-sm font-semibold rounded-md transition"
             >
-              {loading ? "Loading…" : "Load schedule"}
+              {plansLoading ? "Searching…" : "Search"}
             </button>
-          </form>
+          </div>
 
-          {loadError && (
+          {plansError && (
             <p className="mt-4 px-3 py-2 bg-red-50 border border-red-200 rounded text-sm text-red-700">
-              {loadError}
+              {plansError}
             </p>
+          )}
+
+          {/* Plan list */}
+          {plansSearched && !plansLoading && !plansError && (
+            <div className="mt-5">
+              {plans.length === 0 ? (
+                <p className="text-sm text-[#94a3b8]">
+                  No saved plans found for <strong>{studentId.trim()}</strong>.
+                </p>
+              ) : (
+                <>
+                  <p className="text-xs font-medium text-[#64748b] uppercase tracking-wide mb-2">
+                    {plans.length} plan{plans.length !== 1 ? "s" : ""} found — click to load
+                  </p>
+                  <div className="flex flex-col gap-2">
+                    {plans.map((p, i) => {
+                      const isActive =
+                        activePlan?.name === p.name &&
+                        activePlan?.termId === p.termId;
+                      return (
+                        <button
+                          key={`${p.name}-${p.termId}-${i}`}
+                          onClick={() => handleSelectPlan(p)}
+                          className={`text-left px-4 py-3 rounded-lg border transition ${
+                            isActive
+                              ? "bg-[#0F3B2E] text-white border-[#0F3B2E]"
+                              : "bg-[#f8fafc] text-[#334155] border-[#e2e8f0] hover:border-[#0F3B2E] hover:bg-[#f0fdf4]"
+                          }`}
+                        >
+                          <span className="text-sm font-semibold">{p.name}</span>
+                          <span className={`ml-3 text-xs ${isActive ? "text-[#a7d9cc]" : "text-[#64748b]"}`}>
+                            {termLabel(p.termId)} · {p.courseCount} course{p.courseCount !== 1 ? "s" : ""}
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </>
+              )}
+            </div>
           )}
         </section>
 
-        {rawResults !== null && (
-          <section className="space-y-4">
-            <div className="flex flex-wrap items-baseline justify-between gap-2">
-              <h2 className="text-lg font-semibold text-[#1e293b]">
-                Student schedule
-              </h2>
-              <p className="text-sm text-[#64748b]">
-                <span className="font-medium text-[#334155]">
-                  {studentId.trim()}
-                </span>
-                {" · "}
-                {TERM_OPTIONS.find((t) => String(t.value) === termId)?.label ??
-                  termId}
-                {" · "}
-                <span className="italic">{planName.trim()}</span>
-                {" · "}
-                <span className="text-[#0F3B2E] font-semibold">
-                  {totalCredits} credits
-                </span>
-              </p>
-            </div>
-
-            {rawResults.length === 0 ? (
-              <div className="bg-amber-50 border border-amber-200 rounded-lg px-4 py-3 text-sm text-amber-900">
-                No courses in this plan, or the plan does not exist for this
-                student and term.
+        {/* Step 2: Loaded plan editor */}
+        {activePlan && (
+          <>
+            {loadLoading ? (
+              <div className="bg-white border border-[#e2e8f0] rounded-lg p-12 flex items-center justify-center text-[#64748b] text-sm mb-6">
+                Loading schedule…
+              </div>
+            ) : loadError ? (
+              <div className="bg-red-50 border border-red-200 rounded-lg px-4 py-3 text-sm text-red-700 mb-6">
+                {loadError}
               </div>
             ) : (
-              <div className="flex flex-col gap-4 min-h-0">
-                <div className="bg-white border border-[#e2e8f0] rounded-lg overflow-hidden min-h-[520px]">
-                  <WeeklySchedule
-                    registered={registered}
-                    conflicts={conflicts}
-                  />
+              <>
+                {/* Info bar */}
+                <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+                  <div className="flex items-baseline gap-2">
+                    <h2 className="text-lg font-semibold text-[#1e293b]">
+                      {studentId.trim()}'s Schedule
+                    </h2>
+                    <span className="text-sm text-[#64748b]">
+                      {activePlan.name} · {termLabel(activePlan.termId)}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <span
+                      className={`text-xs font-medium px-2 py-0.5 rounded ${
+                        totalCredits > 18
+                          ? "bg-amber-100 text-amber-800 border border-amber-300"
+                          : "bg-[#d1fae5] text-[#065f46]"
+                      }`}
+                    >
+                      {totalCredits} credits{totalCredits > 18 ? " (override)" : ""}
+                    </span>
+                    <button
+                      onClick={handleForceSave}
+                      disabled={saveLoading || courses.length === 0}
+                      className="px-4 py-1.5 bg-[#7c2d12] hover:bg-[#6b2710] disabled:opacity-50 text-white text-sm font-medium rounded-md transition"
+                    >
+                      {saveLoading ? "Saving…" : "Force Save"}
+                    </button>
+                    {saveStatus && (
+                      <p className={`text-sm px-3 py-1.5 rounded ${
+                        saveStatus.includes("success")
+                          ? "bg-green-50 text-green-700 border border-green-200"
+                          : "bg-red-50 text-red-600 border border-red-200"
+                      }`}>
+                        {saveStatus}
+                      </p>
+                    )}
+                  </div>
                 </div>
-              </div>
-            )}
-          </section>
-        )}
 
-        <section className="mt-10 bg-white border border-dashed border-[#cbd5e1] rounded-lg p-6">
-          <h2 className="text-base font-semibold text-[#1e293b] mb-2">
-            Overrides
-          </h2>
-          <p className="text-sm text-[#64748b] leading-relaxed">
-            Time overlaps, credit limits, and enrollment caps will be handled
-            here in a later update. This panel is read-only for now.
-          </p>
-        </section>
+                {/* Main two-panel layout */}
+                <div className="flex gap-4 min-h-0" style={{ height: "calc(100vh - 320px)" }}>
+                  {/* Left: Course search */}
+                  <div className="w-[55%] flex-shrink-0 overflow-y-auto">
+                    <CourseSearch
+                      registered={courses}
+                      onAddCourse={handleAddCourse}
+                      onRemoveCourse={handleRemoveCourse}
+                      conflicts={conflicts}
+                      bypassCreditLimit
+                    />
+                  </div>
+
+                  {/* Right: Schedule + course list */}
+                  <div className="flex-1 flex flex-col gap-4 overflow-y-auto">
+                    {/* Course list */}
+                    <div className="bg-white border border-[#e2e8f0] rounded-lg shadow-sm p-4">
+                      {courses.length === 0 ? (
+                        <p className="text-sm text-[#94a3b8] text-center py-4">
+                          No courses in this plan. Use search to add courses.
+                        </p>
+                      ) : (
+                        <ul className="flex flex-col gap-2">
+                          {courses.map((course) => (
+                            <li
+                              key={course.crn}
+                              className="flex items-center justify-between gap-2 p-2.5 bg-[#f8fafc] border border-[#e2e8f0] rounded-md"
+                            >
+                              <div className="min-w-0">
+                                <p className="text-sm font-medium text-[#1e293b] break-words whitespace-normal">
+                                  {course.name}
+                                </p>
+                                <p className="text-xs text-[#64748b] break-words whitespace-normal">
+                                  {course.courseCode} · {course.credits} cr · {course.meetingDays} {course.meetingTime}
+                                </p>
+                              </div>
+                              <button
+                                onClick={() => handleRemoveCourse(course)}
+                                className="flex-shrink-0 px-2 py-1 text-xs text-red-600 border border-red-200 rounded hover:bg-red-50 transition"
+                              >
+                                Remove
+                              </button>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </div>
+
+                    {/* Weekly schedule */}
+                    <div className="flex-1 min-h-0">
+                      <WeeklySchedule registered={courses} conflicts={conflicts} />
+                    </div>
+                  </div>
+                </div>
+              </>
+            )}
+          </>
+        )}
       </main>
     </div>
   );

--- a/Frontend/src/pages/AdminPage/AdminPage.jsx
+++ b/Frontend/src/pages/AdminPage/AdminPage.jsx
@@ -339,9 +339,9 @@ function AdminPage() {
                 </div>
 
                 {/* Main two-panel layout */}
-                <div className="flex gap-4 min-h-0" style={{ height: "calc(100vh - 320px)" }}>
+                <div className="flex gap-4">
                   {/* Left: Course search */}
-                  <div className="w-[55%] flex-shrink-0 overflow-y-auto">
+                  <div className="w-[55%] flex-shrink-0 overflow-y-auto" style={{ maxHeight: "calc(100vh - 200px)" }}>
                     <CourseSearch
                       registered={courses}
                       onAddCourse={handleAddCourse}
@@ -351,8 +351,8 @@ function AdminPage() {
                     />
                   </div>
 
-                  {/* Right: Schedule + course list */}
-                  <div className="flex-1 flex flex-col gap-4 overflow-y-auto">
+                  {/* Right: Course list + Weekly schedule */}
+                  <div className="flex-1 flex flex-col gap-4 overflow-y-auto" style={{ maxHeight: "calc(100vh - 200px)" }}>
                     {/* Course list */}
                     <div className="bg-white border border-[#e2e8f0] rounded-lg shadow-sm p-4">
                       {courses.length === 0 ? (
@@ -387,7 +387,7 @@ function AdminPage() {
                     </div>
 
                     {/* Weekly schedule */}
-                    <div className="flex-1 min-h-0">
+                    <div style={{ minHeight: "720px" }}>
                       <WeeklySchedule registered={courses} conflicts={conflicts} />
                     </div>
                   </div>

--- a/Frontend/src/pages/HomePage/HomePage.jsx
+++ b/Frontend/src/pages/HomePage/HomePage.jsx
@@ -36,6 +36,8 @@ function HomePage() {
   const [showQuickPlanner, setShowQuickPlanner] = useState(false);
   const [savedQuickPlans, setSavedQuickPlans] = useState([]);
   const [showAdminOverride, setShowAdminOverride] = useState(false);
+  const [registerLoading, setRegisterLoading] = useState(false);
+  const [registerStatus, setRegisterStatus] = useState("");
 
   const menuRef = useRef(null);
   const savePlanModalRef = useRef(null);
@@ -68,51 +70,21 @@ function HomePage() {
   useEffect(() => {
     if (!username) return;
 
-    const loadPlanByNameTerm = async (name, term) => {
-      const params = new URLSearchParams({ user: username, term, name });
-      const res = await fetch(`/api/plans/load?${params}`);
-      if (!res.ok) return [];
-      const data = await res.json();
-      return (data.results ?? []).map(normalizeCourse);
-    };
-
     const autoLoad = async () => {
-      // 1) Try loading from server using last-saved plan info
+      // Load the student's registered schedule from the server
       try {
-        const planInfo = localStorage.getItem(getLastPlanKey(username));
-        if (planInfo) {
-          const { name, term } = JSON.parse(planInfo);
-          if (name && term) {
-            const loaded = await loadPlanByNameTerm(name, term);
-            if (loaded.length > 0) {
-              setRegistered(loaded);
-              return;
-            }
+        const res = await fetch(`/api/plans/registered?user=${encodeURIComponent(username)}`);
+        if (res.ok) {
+          const data = await res.json();
+          const loaded = (data.results ?? []).map(normalizeCourse);
+          if (loaded.length > 0) {
+            setRegistered(loaded);
+            return;
           }
         }
       } catch { /* fall through */ }
 
-      // 2) No local info — fetch the most recent plan from DB
-      try {
-        const listRes = await fetch(`/api/plans/list?user=${encodeURIComponent(username)}`);
-        if (listRes.ok) {
-          const { plans = [] } = await listRes.json();
-          if (plans.length > 0) {
-            const latest = plans[0];
-            const loaded = await loadPlanByNameTerm(latest.name, latest.termId);
-            if (loaded.length > 0) {
-              setRegistered(loaded);
-              localStorage.setItem(
-                getLastPlanKey(username),
-                JSON.stringify({ name: latest.name, term: latest.termId })
-              );
-              return;
-            }
-          }
-        }
-      } catch { /* fall through */ }
-
-      // 3) Last resort: restore from localStorage cache
+      // Fallback: restore from localStorage cache
       try {
         const cached = localStorage.getItem(`schedule_${username}`);
         if (cached) {
@@ -186,6 +158,31 @@ function HomePage() {
     }
   };
 
+
+  const handleRegister = async () => {
+    if (registered.length === 0) return;
+    setRegisterLoading(true);
+    setRegisterStatus("");
+    try {
+      const courseIds = registered.map((c) => c.courseId).filter(Boolean);
+      const res = await fetch("/api/plans/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ user: username, course_ids: courseIds }),
+      });
+      if (!res.ok) throw new Error(`Server error: ${res.status}`);
+      setRegisterStatus("registered");
+      try {
+        localStorage.setItem(`schedule_${username}`, JSON.stringify(registered));
+      } catch { /* ignore */ }
+      setTimeout(() => setRegisterStatus(""), 3000);
+    } catch {
+      setRegisterStatus("error");
+      setTimeout(() => setRegisterStatus(""), 3000);
+    } finally {
+      setRegisterLoading(false);
+    }
+  };
 
   const handleSaveQuickPlans = (plans) => {
     setSavedQuickPlans(plans);
@@ -286,6 +283,25 @@ function HomePage() {
               className="px-3 py-1.5 text-xs font-medium text-white bg-[#1a5c45] border border-[#2d7a5f] rounded-md hover:bg-[#226b52] transition"
             >
               Save Plan
+            </button>
+            <button
+              onClick={handleRegister}
+              disabled={registerLoading || registered.length === 0}
+              className={`px-3 py-1.5 text-xs font-medium rounded-md transition border ${
+                registerStatus === "registered"
+                  ? "bg-green-600 border-green-500 text-white"
+                  : registerStatus === "error"
+                  ? "bg-red-600 border-red-500 text-white"
+                  : "bg-[#b45309] border-[#d97706] text-white hover:bg-[#92400e] disabled:opacity-40"
+              }`}
+            >
+              {registerLoading
+                ? "Registering…"
+                : registerStatus === "registered"
+                ? "Registered!"
+                : registerStatus === "error"
+                ? "Failed"
+                : "Register"}
             </button>
           </div>
 

--- a/Frontend/src/pages/HomePage/HomePage.jsx
+++ b/Frontend/src/pages/HomePage/HomePage.jsx
@@ -136,7 +136,7 @@ function HomePage() {
       try {
         localStorage.setItem(
           getLastPlanKey(username),
-          JSON.stringify({ name: planName.trim(), term: planTermId })
+          JSON.stringify({ name: planName.trim(), term: parseInt(planTermId) })
         );
         localStorage.setItem(
           `schedule_${username}`,

--- a/Frontend/src/pages/HomePage/HomePage.jsx
+++ b/Frontend/src/pages/HomePage/HomePage.jsx
@@ -12,10 +12,6 @@ function getQuickPlanStorageKey(user) {
   return `quickPlans_${user}`;
 }
 
-function getLastPlanKey(user) {
-  return `lastPlan_${user}`;
-}
-
 function normalizeCourse(raw) {
   return {
     ...raw,
@@ -75,7 +71,6 @@ function HomePage() {
     if (!username) return;
 
     const autoLoad = async () => {
-      // Load the student's registered schedule from the server
       try {
         const res = await fetch(`/api/plans/registered?user=${encodeURIComponent(username)}`);
         if (res.ok) {
@@ -83,18 +78,6 @@ function HomePage() {
           const loaded = (data.results ?? []).map(normalizeCourse);
           if (loaded.length > 0) {
             setRegistered(loaded);
-            return;
-          }
-        }
-      } catch { /* fall through */ }
-
-      // Fallback: restore from localStorage cache
-      try {
-        const cached = localStorage.getItem(`schedule_${username}`);
-        if (cached) {
-          const parsed = JSON.parse(cached);
-          if (Array.isArray(parsed) && parsed.length > 0) {
-            setRegistered(parsed);
           }
         }
       } catch { /* ignore */ }
@@ -145,16 +128,6 @@ function HomePage() {
       });
       if (!res.ok) throw new Error(`Server error: ${res.status}`);
       setPlanStatus("Plan saved successfully!");
-      try {
-        localStorage.setItem(
-          getLastPlanKey(username),
-          JSON.stringify({ name: planName.trim(), term: parseInt(planTermId) })
-        );
-        localStorage.setItem(
-          `schedule_${username}`,
-          JSON.stringify(registered)
-        );
-      } catch { /* ignore */ }
     } catch (err) {
       setPlanStatus(err.message || "Failed to save plan.");
     } finally {
@@ -213,9 +186,6 @@ function HomePage() {
       });
       if (!res.ok) throw new Error(`Server error: ${res.status}`);
       setRegisterStatus("registered");
-      try {
-        localStorage.setItem(`schedule_${username}`, JSON.stringify(registered));
-      } catch { /* ignore */ }
       setTimeout(() => setRegisterStatus(""), 3000);
     } catch {
       setRegisterStatus("error");

--- a/Frontend/src/pages/HomePage/HomePage.jsx
+++ b/Frontend/src/pages/HomePage/HomePage.jsx
@@ -66,28 +66,52 @@ function HomePage() {
 
   useEffect(() => {
     if (!username) return;
+
+    const loadPlanByNameTerm = async (name, term) => {
+      const params = new URLSearchParams({ user: username, term, name });
+      const res = await fetch(`/api/plans/load?${params}`);
+      if (!res.ok) return [];
+      const data = await res.json();
+      return (data.results ?? []).map(normalizeCourse);
+    };
+
     const autoLoad = async () => {
-      // 1) Try loading from server using saved plan info
+      // 1) Try loading from server using last-saved plan info
       try {
         const planInfo = localStorage.getItem(getLastPlanKey(username));
         if (planInfo) {
           const { name, term } = JSON.parse(planInfo);
           if (name && term) {
-            const params = new URLSearchParams({ user: username, term, name });
-            const res = await fetch(`/api/plans/load?${params}`);
-            if (res.ok) {
-              const data = await res.json();
-              const loaded = (data.results ?? []).map(normalizeCourse);
-              if (loaded.length > 0) {
-                setRegistered(loaded);
-                return;
-              }
+            const loaded = await loadPlanByNameTerm(name, term);
+            if (loaded.length > 0) {
+              setRegistered(loaded);
+              return;
             }
           }
         }
-      } catch { /* fall through to cache */ }
+      } catch { /* fall through */ }
 
-      // 2) Fallback: restore from localStorage cache
+      // 2) No local info — fetch the most recent plan from DB
+      try {
+        const listRes = await fetch(`/api/plans/list?user=${encodeURIComponent(username)}`);
+        if (listRes.ok) {
+          const { plans = [] } = await listRes.json();
+          if (plans.length > 0) {
+            const latest = plans[0];
+            const loaded = await loadPlanByNameTerm(latest.name, latest.termId);
+            if (loaded.length > 0) {
+              setRegistered(loaded);
+              localStorage.setItem(
+                getLastPlanKey(username),
+                JSON.stringify({ name: latest.name, term: latest.termId })
+              );
+              return;
+            }
+          }
+        }
+      } catch { /* fall through */ }
+
+      // 3) Last resort: restore from localStorage cache
       try {
         const cached = localStorage.getItem(`schedule_${username}`);
         if (cached) {

--- a/Frontend/src/pages/HomePage/HomePage.jsx
+++ b/Frontend/src/pages/HomePage/HomePage.jsx
@@ -38,6 +38,10 @@ function HomePage() {
   const [showAdminOverride, setShowAdminOverride] = useState(false);
   const [registerLoading, setRegisterLoading] = useState(false);
   const [registerStatus, setRegisterStatus] = useState("");
+  const [showLoadModal, setShowLoadModal] = useState(false);
+  const [savedPlans, setSavedPlans] = useState([]);
+  const [loadingPlans, setLoadingPlans] = useState(false);
+  const [loadingPlanName, setLoadingPlanName] = useState(null);
 
   const menuRef = useRef(null);
   const savePlanModalRef = useRef(null);
@@ -159,6 +163,43 @@ function HomePage() {
   };
 
 
+  const openLoadModal = async () => {
+    setShowLoadModal(true);
+    setLoadingPlans(true);
+    try {
+      const res = await fetch(`/api/plans/list?user=${encodeURIComponent(username)}`);
+      if (!res.ok) throw new Error();
+      const data = await res.json();
+      setSavedPlans(data.plans ?? []);
+    } catch {
+      setSavedPlans([]);
+    } finally {
+      setLoadingPlans(false);
+    }
+  };
+
+  const handleLoadPlan = async (plan) => {
+    setLoadingPlanName(plan.name);
+    try {
+      const params = new URLSearchParams({
+        user: username,
+        term: String(plan.termId),
+        name: plan.name,
+      });
+      const res = await fetch(`/api/plans/load?${params}`);
+      if (!res.ok) throw new Error();
+      const data = await res.json();
+      const loaded = (data.results ?? []).map(normalizeCourse);
+      if (loaded.length > 0) {
+        setRegistered(loaded);
+      }
+      setShowLoadModal(false);
+    } catch { /* ignore */ }
+    finally {
+      setLoadingPlanName(null);
+    }
+  };
+
   const handleRegister = async () => {
     if (registered.length === 0) return;
     setRegisterLoading(true);
@@ -277,6 +318,12 @@ function HomePage() {
               {savedQuickPlans.length > 0 && !showQuickPlanner && (
                 <span className="absolute -top-1 -right-1 w-2.5 h-2.5 bg-green-400 rounded-full border border-white" />
               )}
+            </button>
+            <button
+              onClick={openLoadModal}
+              className="px-3 py-1.5 text-xs font-medium text-white bg-[#475569] border border-[#64748b] rounded-md hover:bg-[#334155] transition"
+            >
+              Load Plan
             </button>
             <button
               onClick={openSavePlan}
@@ -404,6 +451,52 @@ function HomePage() {
                 </button>
               </div>
             </div>
+          </div>
+        </div>
+      )}
+
+      {showLoadModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div className="absolute inset-0 bg-black/40" onClick={() => setShowLoadModal(false)} />
+          <div
+            role="dialog"
+            aria-modal="true"
+            className="relative z-10 bg-white rounded-lg shadow-xl p-6 w-full max-w-md mx-4 max-h-[70vh] flex flex-col"
+          >
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-base font-semibold text-[#1e293b]">Load Plan</h2>
+              <button
+                onClick={() => setShowLoadModal(false)}
+                className="text-[#94a3b8] hover:text-[#475569] transition text-lg leading-none"
+              >
+                &times;
+              </button>
+            </div>
+
+            {loadingPlans ? (
+              <p className="text-sm text-[#64748b] text-center py-8">Loading plans…</p>
+            ) : savedPlans.length === 0 ? (
+              <p className="text-sm text-[#94a3b8] text-center py-8">No saved plans found.</p>
+            ) : (
+              <div className="flex flex-col gap-2 overflow-y-auto">
+                {savedPlans.map((p, i) => (
+                  <button
+                    key={`${p.name}-${p.termId}-${i}`}
+                    onClick={() => handleLoadPlan(p)}
+                    disabled={loadingPlanName === p.name}
+                    className="text-left px-4 py-3 rounded-lg border border-[#e2e8f0] bg-[#f8fafc] hover:border-[#0F3B2E] hover:bg-[#f0fdf4] transition disabled:opacity-50"
+                  >
+                    <span className="text-sm font-semibold text-[#1e293b]">{p.name}</span>
+                    <span className="ml-2 text-xs text-[#64748b]">
+                      Term {p.termId} · {p.courseCount} course{p.courseCount !== 1 ? "s" : ""}
+                    </span>
+                    {loadingPlanName === p.name && (
+                      <span className="ml-2 text-xs text-[#0F3B2E]">Loading…</span>
+                    )}
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
         </div>
       )}

--- a/Frontend/src/pages/HomePage/HomePage.jsx
+++ b/Frontend/src/pages/HomePage/HomePage.jsx
@@ -4,6 +4,7 @@ import CourseSearch from "../../components/CourseSearch/CourseSearch";
 import WeeklySchedule from "../../components/WeeklySchedule/WeeklySchedule";
 import MySchedule from "../../components/MySchedule/MySchedule";
 import QuickPlanner from "../../components/QuickPlanner/QuickPlanner";
+import AdminOverride from "../../components/AdminOverride/AdminOverride";
 import { detectConflicts } from "../../utils/courseUtils";
 import wayneLogo from "../../assets/images/wayneLogo.png";
 
@@ -34,11 +35,14 @@ function HomePage() {
   const [planLoading, setPlanLoading] = useState(false);
   const [showQuickPlanner, setShowQuickPlanner] = useState(false);
   const [savedQuickPlans, setSavedQuickPlans] = useState([]);
+  const [showAdminOverride, setShowAdminOverride] = useState(false);
 
   const menuRef = useRef(null);
   const navigate = useNavigate();
 
   const username = localStorage.getItem("username") || "";
+  const userRole = localStorage.getItem("userRole") || "";
+  const isAdmin = userRole === "admin";
 
   useEffect(() => {
     if (localStorage.getItem("userRole") === "admin") {
@@ -204,6 +208,14 @@ function HomePage() {
           </div>
 
           <div className="flex items-center gap-2">
+            {isAdmin && (
+              <button
+                onClick={() => setShowAdminOverride(true)}
+                className="px-3 py-1.5 text-xs font-medium text-white bg-red-700 border border-red-500 rounded-md hover:bg-red-800 transition"
+              >
+                Admin Override
+              </button>
+            )}
             <button
               onClick={() => setShowQuickPlanner(true)}
               className="relative px-3 py-1.5 text-xs font-medium text-white bg-[#2563eb] border border-[#3b82f6] rounded-md hover:bg-[#1d4ed8] transition"
@@ -347,6 +359,10 @@ function HomePage() {
           savedPlans={savedQuickPlans}
           onSavePlans={handleSaveQuickPlans}
         />
+      )}
+
+      {showAdminOverride && (
+        <AdminOverride onClose={() => setShowAdminOverride(false)} />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
Implement admin schedule override functionality (FR-14) and student Register button (FR-32). Administrators can now look up any student's registered schedule, modify it (bypassing the 18-credit limit), and force-save changes. Students can register their current schedule via a dedicated Register button, browse/load previously saved plans, and see their registered schedule automatically on login.

## Changes
- Add `register_courses()` and `load_registered_courses()` backend service functions using a reserved `__registered__` plan name in the existing `plan` table
- Add new API endpoints: `POST /api/plans/register`, `GET /api/plans/registered`, `GET /api/plans/list`, `GET /api/admin/plans/registered`, `POST /api/admin/plans/register`, `GET /api/admin/plans/list`, `POST /api/admin/plans/save`
- Add `RegisterCourseList`, `AdminCourseList`, and `AdminRegisterCourseList` Pydantic schemas
- Add `updated_at` timestamp column to plan table for recency-based ordering; `__registered__` entries hidden from plan list queries
- Fix `load_courses_from_plan` returning empty results due to `term_id` mismatch between `plan` and `section` tables
- Add error handling and explicit rollback to `save_courses_to_plan`
- Add Register button to student HomePage — sends current schedule to server as the active registered plan
- Add Load Plan modal to student HomePage — browse and restore any previously saved plan
- Auto-load registered schedule from server on student login (removed stale localStorage cache fallback)
- Simplify AdminPage: student ID search directly loads registered schedule; Force Save updates it via admin register endpoint
- Add `AdminOverride` component accessible from HomePage header for admin users to override student schedules
- Add `bypassCreditLimit` prop to `CourseSearch` for admin override flows
- Remove unused `onSave`/`saveStatus` props from `MySchedule` component

## Type of Change
- [x] New feature
- [ ] Bug fix
- [x] Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Configuration

## Screenshots (if applicable)


https://github.com/user-attachments/assets/60b35ecb-4b0b-4d88-beaf-6c06fd70153e



## Related Issue
Closes #14

## Deployment
- Deployment URL: 

## Additional Notes
- Requires one-time DB migration: `ALTER TABLE plan ADD COLUMN updated_at TIMESTAMP DEFAULT NOW()`
- Registered schedules are stored in the `plan` table with `name = '__registered__'` and `is_active = true`, keeping the schema unchanged beyond the `updated_at` column
- The existing Save Plan / Load Plan flow is preserved as a separate feature from Register — students can save multiple named plans and load them, but only one registered schedule exists per student
- Admin Force Save directly updates the student's registered schedule, which the student will see on their next login