### PR TITLE
Implement the Register button

### DIFF
--- a/Backend/routers/admin.py
+++ b/Backend/routers/admin.py
@@ -4,8 +4,10 @@ from Backend.services.plan_service import (
     load_courses_from_plan,
     save_courses_to_plan,
     list_student_plans,
+    load_registered_courses,
+    register_courses,
 )
-from Backend.schemas.plan_schema import AdminCourseList
+from Backend.schemas.plan_schema import AdminCourseList, AdminRegisterCourseList
 
 router = APIRouter()
 
@@ -47,6 +49,19 @@ def admin_load_student_plan(
         name=name
     )
 
+
+@router.get("/plans/registered")
+def admin_get_registered(
+    admin_user: str = Query(...),
+    student_id: str = Query(...),
+):
+    _verify_admin(admin_user)
+    return load_registered_courses(student_id)
+
+@router.post("/plans/register")
+def admin_register_student_plan(data: AdminRegisterCourseList):
+    _verify_admin(data.admin_user)
+    return register_courses(user=data.student_id, course_ids=data.course_ids)
 
 @router.post("/plans/save")
 def admin_save_student_plan(data: AdminCourseList):

--- a/Backend/routers/plans.py
+++ b/Backend/routers/plans.py
@@ -1,6 +1,13 @@
 from fastapi import APIRouter, Query
-from Backend.schemas.plan_schema import CourseList
-from Backend.services.plan_service import save_courses_to_plan, load_courses_from_plan, load_plans_from_user, list_student_plans
+from Backend.schemas.plan_schema import CourseList, RegisterCourseList
+from Backend.services.plan_service import (
+    save_courses_to_plan,
+    load_courses_from_plan,
+    load_plans_from_user,
+    list_student_plans,
+    register_courses,
+    load_registered_courses,
+)
 
 router = APIRouter()
 
@@ -20,6 +27,14 @@ def load_courses(user: str, term: int, name: str):
         term=term,
         name=name
     )
+
+@router.post("/register")
+def register(data: RegisterCourseList):
+    return register_courses(user=data.user, course_ids=data.course_ids)
+
+@router.get("/registered")
+def get_registered(user: str):
+    return load_registered_courses(user)
 
 @router.get("/list")
 def list_plans(user: str):

--- a/Backend/schemas/plan_schema.py
+++ b/Backend/schemas/plan_schema.py
@@ -6,9 +6,18 @@ class CourseList(BaseModel):
     term: int
     name: str
 
+class RegisterCourseList(BaseModel):
+    user: str
+    course_ids: list[int]
+
 class AdminCourseList(BaseModel):
     admin_user: str
     student_id: str
     course_ids: list[int]
     term: int
     name: str
+
+class AdminRegisterCourseList(BaseModel):
+    admin_user: str
+    student_id: str
+    course_ids: list[int]

--- a/Backend/services/plan_service.py
+++ b/Backend/services/plan_service.py
@@ -144,6 +144,98 @@ def load_plans_from_user(user: str):
         conn.close()
 
 
+REGISTERED_PLAN_NAME = "__registered__"
+
+
+def register_courses(user: str, course_ids: list[int]):
+    conn = get_conn()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            "DELETE FROM plan WHERE student_id = %s AND name = %s",
+            (user, REGISTERED_PLAN_NAME),
+        )
+        for cid in course_ids:
+            cur.execute(
+                "INSERT INTO plan (student_id, course_id, term_id, name, is_active, updated_at) "
+                "VALUES (%s, %s, 0, %s, true, NOW())",
+                (user, cid, REGISTERED_PLAN_NAME),
+            )
+        conn.commit()
+    except Exception as e:
+        conn.rollback()
+        raise HTTPException(status_code=500, detail=f"Failed to register: {e}")
+    finally:
+        conn.close()
+    return {"success": True, "registered": course_ids}
+
+
+def load_registered_courses(user: str):
+    conn = get_conn()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT course_id FROM plan WHERE student_id = %s AND name = %s",
+            (user, REGISTERED_PLAN_NAME),
+        )
+        course_ids = [r["course_id"] for r in cur.fetchall()]
+
+        if not course_ids:
+            return {"results": []}
+
+        sql = """
+        SELECT
+            s."CRN" AS crn, s.term_id, s.max_reg, s.registered,
+            c.id AS course_id, c.subject, c.course_number, c.title,
+            c.credit_hours, c.instructor, c.building, c.room_number,
+            t.monday, t.tuesday, t.wednesday, t.thursday, t.friday,
+            t.start_min, t.end_min
+        FROM section s
+        JOIN course c ON c.id = s.course_id
+        LEFT JOIN time_slot t ON t.id = c.id
+        WHERE c.id = ANY(%s)
+        ORDER BY c.subject, c.course_number
+        """
+        cur.execute(sql, (course_ids,))
+        rows = cur.fetchall()
+    finally:
+        conn.close()
+
+    results = []
+    for r in rows:
+        max_seats = r["max_reg"] or 0
+        registered_seats = r["registered"] or 0
+        results.append({
+            "courseId": r["course_id"],
+            "subject": r["subject"],
+            "courseNumber": r["course_number"],
+            "courseCode": f"{r['subject']} {r['course_number']}",
+            "crn": str(r["crn"]),
+            "term": str(r["term_id"]),
+            "name": r["title"],
+            "credits": r["credit_hours"],
+            "instructor": r["instructor"] or "TBA",
+            "days": days_str(r),
+            "time": format_time_range(r),
+            "location": format_location(r),
+            "meetingDays": days_str(r),
+            "meetingTime": format_time_range(r),
+            "building": r["building"],
+            "room": r["room_number"],
+            "startMin": r["start_min"],
+            "endMin": r["end_min"],
+            "monday": r["monday"],
+            "tuesday": r["tuesday"],
+            "wednesday": r["wednesday"],
+            "thursday": r["thursday"],
+            "friday": r["friday"],
+            "maxSeats": max_seats,
+            "registeredSeats": registered_seats,
+            "availableSeats": max_seats - registered_seats,
+        })
+    return {"results": results}
+
+
 def list_student_plans(user: str):
     conn = get_conn()
     try:
@@ -154,11 +246,11 @@ def list_student_plans(user: str):
                COUNT(course_id) AS course_count,
                MAX(updated_at) AS last_updated
         FROM plan
-        WHERE student_id = %s
+        WHERE student_id = %s AND name != %s
         GROUP BY name, term_id
         ORDER BY last_updated DESC NULLS LAST, term_id DESC, name
         """
-        cur.execute(sql, (user,))
+        cur.execute(sql, (user, REGISTERED_PLAN_NAME))
         rows = cur.fetchall()
 
         return {

--- a/Frontend/src/pages/AdminPage/AdminPage.jsx
+++ b/Frontend/src/pages/AdminPage/AdminPage.jsx
@@ -5,15 +5,6 @@ import WeeklySchedule from "../../components/WeeklySchedule/WeeklySchedule";
 import { detectConflicts } from "../../utils/courseUtils";
 import wayneLogo from "../../assets/images/wayneLogo.png";
 
-const TERM_OPTIONS = [
-  { label: "Spring/Summer 2026", value: 202601 },
-  { label: "Fall 2026", value: 202609 },
-];
-
-function termLabel(termId) {
-  return TERM_OPTIONS.find((t) => t.value === termId)?.label ?? String(termId);
-}
-
 function normalizePlanCourse(c) {
   return {
     ...c,
@@ -30,15 +21,10 @@ function AdminPage() {
   const userRole = localStorage.getItem("userRole") || "";
 
   const [studentId, setStudentId] = useState("");
-  const [plans, setPlans] = useState([]);
-  const [plansLoading, setPlansLoading] = useState(false);
-  const [plansError, setPlansError] = useState("");
-  const [plansSearched, setPlansSearched] = useState(false);
-
-  const [activePlan, setActivePlan] = useState(null);
   const [courses, setCourses] = useState([]);
-  const [loadLoading, setLoadLoading] = useState(false);
-  const [loadError, setLoadError] = useState("");
+  const [searchLoading, setSearchLoading] = useState(false);
+  const [searchError, setSearchError] = useState("");
+  const [searched, setSearched] = useState(false);
 
   const [saveStatus, setSaveStatus] = useState("");
   const [saveLoading, setSaveLoading] = useState(false);
@@ -59,16 +45,14 @@ function AdminPage() {
     [courses]
   );
 
-  const handleSearchPlans = async () => {
+  const handleSearchRegistered = async () => {
     const sid = studentId.trim();
-    if (!sid) { setPlansError("Enter a Student ID."); return; }
+    if (!sid) { setSearchError("Enter a Student ID."); return; }
 
-    setPlansLoading(true);
-    setPlansError("");
-    setPlansSearched(true);
-    setActivePlan(null);
+    setSearchLoading(true);
+    setSearchError("");
+    setSearched(true);
     setCourses([]);
-    setLoadError("");
     setSaveStatus("");
 
     try {
@@ -76,35 +60,7 @@ function AdminPage() {
         admin_user: username,
         student_id: sid,
       });
-      const res = await fetch(`/api/admin/plans/list?${params}`);
-      if (!res.ok) {
-        const err = await res.json().catch(() => null);
-        throw new Error(err?.detail || `Server error: ${res.status}`);
-      }
-      const data = await res.json();
-      setPlans(data.plans ?? []);
-    } catch (err) {
-      setPlansError(err.message || "Failed to fetch plans.");
-      setPlans([]);
-    } finally {
-      setPlansLoading(false);
-    }
-  };
-
-  const handleSelectPlan = async (plan) => {
-    setActivePlan(plan);
-    setLoadLoading(true);
-    setLoadError("");
-    setSaveStatus("");
-
-    try {
-      const params = new URLSearchParams({
-        admin_user: username,
-        student_id: studentId.trim(),
-        term: String(plan.termId),
-        name: plan.name,
-      });
-      const res = await fetch(`/api/admin/plans/load?${params}`);
+      const res = await fetch(`/api/admin/plans/registered?${params}`);
       if (!res.ok) {
         const err = await res.json().catch(() => null);
         throw new Error(err?.detail || `Server error: ${res.status}`);
@@ -112,10 +68,10 @@ function AdminPage() {
       const data = await res.json();
       setCourses((data.results ?? []).map(normalizePlanCourse));
     } catch (err) {
-      setLoadError(err.message || "Failed to load plan.");
+      setSearchError(err.message || "Failed to load registered schedule.");
       setCourses([]);
     } finally {
-      setLoadLoading(false);
+      setSearchLoading(false);
     }
   };
 
@@ -130,29 +86,26 @@ function AdminPage() {
   };
 
   const handleForceSave = async () => {
-    if (!activePlan) return;
     setSaveLoading(true);
     setSaveStatus("");
     try {
       const courseIds = courses.map((c) => c.courseId).filter(Boolean);
-      const res = await fetch("/api/admin/plans/save", {
+      const res = await fetch("/api/admin/plans/register", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           admin_user: username,
           student_id: studentId.trim(),
           course_ids: courseIds,
-          term: activePlan.termId,
-          name: activePlan.name,
         }),
       });
       if (!res.ok) {
         const err = await res.json().catch(() => null);
         throw new Error(err?.detail || `Server error: ${res.status}`);
       }
-      setSaveStatus("Plan saved successfully!");
+      setSaveStatus("Registered schedule updated!");
     } catch (err) {
-      setSaveStatus(err.message || "Failed to save plan.");
+      setSaveStatus(err.message || "Failed to update registered schedule.");
     } finally {
       setSaveLoading(false);
     }
@@ -212,7 +165,7 @@ function AdminPage() {
             Look up a student
           </h2>
           <p className="text-sm text-[#64748b] mb-5">
-            Enter a student ID to see all their saved plans.
+            Enter a student ID to view and edit their registered schedule.
           </p>
 
           <div className="flex flex-col gap-4 sm:flex-row sm:flex-wrap sm:items-end">
@@ -225,119 +178,69 @@ function AdminPage() {
                 type="text"
                 value={studentId}
                 onChange={(e) => setStudentId(e.target.value)}
-                onKeyDown={(e) => e.key === "Enter" && handleSearchPlans()}
+                onKeyDown={(e) => e.key === "Enter" && handleSearchRegistered()}
                 placeholder="e.g. student1"
                 className="w-full px-3 py-2 border border-[#e2e8f0] rounded-md text-sm text-[#334155] outline-none focus:border-[#0F3B2E] focus:ring-2 focus:ring-[#0F3B2E]/10"
                 autoComplete="off"
               />
             </div>
             <button
-              onClick={handleSearchPlans}
-              disabled={plansLoading}
+              onClick={handleSearchRegistered}
+              disabled={searchLoading}
               className="px-5 py-2 bg-[#0F3B2E] hover:bg-[#0a2a20] disabled:opacity-50 text-white text-sm font-semibold rounded-md transition"
             >
-              {plansLoading ? "Searching…" : "Search"}
+              {searchLoading ? "Loading…" : "Search"}
             </button>
           </div>
 
-          {plansError && (
+          {searchError && (
             <p className="mt-4 px-3 py-2 bg-red-50 border border-red-200 rounded text-sm text-red-700">
-              {plansError}
+              {searchError}
             </p>
-          )}
-
-          {/* Plan list */}
-          {plansSearched && !plansLoading && !plansError && (
-            <div className="mt-5">
-              {plans.length === 0 ? (
-                <p className="text-sm text-[#94a3b8]">
-                  No saved plans found for <strong>{studentId.trim()}</strong>.
-                </p>
-              ) : (
-                <>
-                  <p className="text-xs font-medium text-[#64748b] uppercase tracking-wide mb-2">
-                    {plans.length} plan{plans.length !== 1 ? "s" : ""} found — click to load
-                  </p>
-                  <div className="flex flex-col gap-2">
-                    {plans.map((p, i) => {
-                      const isActive =
-                        activePlan?.name === p.name &&
-                        activePlan?.termId === p.termId;
-                      return (
-                        <button
-                          key={`${p.name}-${p.termId}-${i}`}
-                          onClick={() => handleSelectPlan(p)}
-                          className={`text-left px-4 py-3 rounded-lg border transition ${
-                            isActive
-                              ? "bg-[#0F3B2E] text-white border-[#0F3B2E]"
-                              : "bg-[#f8fafc] text-[#334155] border-[#e2e8f0] hover:border-[#0F3B2E] hover:bg-[#f0fdf4]"
-                          }`}
-                        >
-                          <span className="text-sm font-semibold">{p.name}</span>
-                          <span className={`ml-3 text-xs ${isActive ? "text-[#a7d9cc]" : "text-[#64748b]"}`}>
-                            {termLabel(p.termId)} · {p.courseCount} course{p.courseCount !== 1 ? "s" : ""}
-                          </span>
-                        </button>
-                      );
-                    })}
-                  </div>
-                </>
-              )}
-            </div>
           )}
         </section>
 
-        {/* Step 2: Loaded plan editor */}
-        {activePlan && (
+        {/* Registered schedule editor */}
+        {searched && !searchLoading && !searchError && (
           <>
-            {loadLoading ? (
-              <div className="bg-white border border-[#e2e8f0] rounded-lg p-12 flex items-center justify-center text-[#64748b] text-sm mb-6">
-                Loading schedule…
+            {/* Info bar */}
+            <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+              <div className="flex items-baseline gap-2">
+                <h2 className="text-lg font-semibold text-[#1e293b]">
+                  {studentId.trim()}'s Registered Schedule
+                </h2>
+                {courses.length === 0 && (
+                  <span className="text-sm text-[#94a3b8]">— no registered courses</span>
+                )}
               </div>
-            ) : loadError ? (
-              <div className="bg-red-50 border border-red-200 rounded-lg px-4 py-3 text-sm text-red-700 mb-6">
-                {loadError}
+              <div className="flex items-center gap-3">
+                <span
+                  className={`text-xs font-medium px-2 py-0.5 rounded ${
+                    totalCredits > 18
+                      ? "bg-amber-100 text-amber-800 border border-amber-300"
+                      : "bg-[#d1fae5] text-[#065f46]"
+                  }`}
+                >
+                  {totalCredits} credits{totalCredits > 18 ? " (override)" : ""}
+                </span>
+                <button
+                  onClick={handleForceSave}
+                  disabled={saveLoading || courses.length === 0}
+                  className="px-4 py-1.5 bg-[#7c2d12] hover:bg-[#6b2710] disabled:opacity-50 text-white text-sm font-medium rounded-md transition"
+                >
+                  {saveLoading ? "Saving…" : "Force Save"}
+                </button>
+                {saveStatus && (
+                  <p className={`text-sm px-3 py-1.5 rounded ${
+                    saveStatus.includes("updated") || saveStatus.includes("success")
+                      ? "bg-green-50 text-green-700 border border-green-200"
+                      : "bg-red-50 text-red-600 border border-red-200"
+                  }`}>
+                    {saveStatus}
+                  </p>
+                )}
               </div>
-            ) : (
-              <>
-                {/* Info bar */}
-                <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
-                  <div className="flex items-baseline gap-2">
-                    <h2 className="text-lg font-semibold text-[#1e293b]">
-                      {studentId.trim()}'s Schedule
-                    </h2>
-                    <span className="text-sm text-[#64748b]">
-                      {activePlan.name} · {termLabel(activePlan.termId)}
-                    </span>
-                  </div>
-                  <div className="flex items-center gap-3">
-                    <span
-                      className={`text-xs font-medium px-2 py-0.5 rounded ${
-                        totalCredits > 18
-                          ? "bg-amber-100 text-amber-800 border border-amber-300"
-                          : "bg-[#d1fae5] text-[#065f46]"
-                      }`}
-                    >
-                      {totalCredits} credits{totalCredits > 18 ? " (override)" : ""}
-                    </span>
-                    <button
-                      onClick={handleForceSave}
-                      disabled={saveLoading || courses.length === 0}
-                      className="px-4 py-1.5 bg-[#7c2d12] hover:bg-[#6b2710] disabled:opacity-50 text-white text-sm font-medium rounded-md transition"
-                    >
-                      {saveLoading ? "Saving…" : "Force Save"}
-                    </button>
-                    {saveStatus && (
-                      <p className={`text-sm px-3 py-1.5 rounded ${
-                        saveStatus.includes("success")
-                          ? "bg-green-50 text-green-700 border border-green-200"
-                          : "bg-red-50 text-red-600 border border-red-200"
-                      }`}>
-                        {saveStatus}
-                      </p>
-                    )}
-                  </div>
-                </div>
+            </div>
 
                 {/* Main two-panel layout */}
                 <div className="flex gap-4">
@@ -393,8 +296,6 @@ function AdminPage() {
                     </div>
                   </div>
                 </div>
-              </>
-            )}
           </>
         )}
       </main>

--- a/Frontend/src/pages/HomePage/HomePage.jsx
+++ b/Frontend/src/pages/HomePage/HomePage.jsx
@@ -36,6 +36,8 @@ function HomePage() {
   const [showQuickPlanner, setShowQuickPlanner] = useState(false);
   const [savedQuickPlans, setSavedQuickPlans] = useState([]);
   const [showAdminOverride, setShowAdminOverride] = useState(false);
+  const [registerLoading, setRegisterLoading] = useState(false);
+  const [registerStatus, setRegisterStatus] = useState("");
 
   const menuRef = useRef(null);
   const savePlanModalRef = useRef(null);
@@ -68,51 +70,21 @@ function HomePage() {
   useEffect(() => {
     if (!username) return;
 
-    const loadPlanByNameTerm = async (name, term) => {
-      const params = new URLSearchParams({ user: username, term, name });
-      const res = await fetch(`/api/plans/load?${params}`);
-      if (!res.ok) return [];
-      const data = await res.json();
-      return (data.results ?? []).map(normalizeCourse);
-    };
-
     const autoLoad = async () => {
-      // 1) Try loading from server using last-saved plan info
+      // Load the student's registered schedule from the server
       try {
-        const planInfo = localStorage.getItem(getLastPlanKey(username));
-        if (planInfo) {
-          const { name, term } = JSON.parse(planInfo);
-          if (name && term) {
-            const loaded = await loadPlanByNameTerm(name, term);
-            if (loaded.length > 0) {
-              setRegistered(loaded);
-              return;
-            }
+        const res = await fetch(`/api/plans/registered?user=${encodeURIComponent(username)}`);
+        if (res.ok) {
+          const data = await res.json();
+          const loaded = (data.results ?? []).map(normalizeCourse);
+          if (loaded.length > 0) {
+            setRegistered(loaded);
+            return;
           }
         }
       } catch { /* fall through */ }
 
-      // 2) No local info — fetch the most recent plan from DB
-      try {
-        const listRes = await fetch(`/api/plans/list?user=${encodeURIComponent(username)}`);
-        if (listRes.ok) {
-          const { plans = [] } = await listRes.json();
-          if (plans.length > 0) {
-            const latest = plans[0];
-            const loaded = await loadPlanByNameTerm(latest.name, latest.termId);
-            if (loaded.length > 0) {
-              setRegistered(loaded);
-              localStorage.setItem(
-                getLastPlanKey(username),
-                JSON.stringify({ name: latest.name, term: latest.termId })
-              );
-              return;
-            }
-          }
-        }
-      } catch { /* fall through */ }
-
-      // 3) Last resort: restore from localStorage cache
+      // Fallback: restore from localStorage cache
       try {
         const cached = localStorage.getItem(`schedule_${username}`);
         if (cached) {
@@ -186,6 +158,31 @@ function HomePage() {
     }
   };
 
+
+  const handleRegister = async () => {
+    if (registered.length === 0) return;
+    setRegisterLoading(true);
+    setRegisterStatus("");
+    try {
+      const courseIds = registered.map((c) => c.courseId).filter(Boolean);
+      const res = await fetch("/api/plans/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ user: username, course_ids: courseIds }),
+      });
+      if (!res.ok) throw new Error(`Server error: ${res.status}`);
+      setRegisterStatus("registered");
+      try {
+        localStorage.setItem(`schedule_${username}`, JSON.stringify(registered));
+      } catch { /* ignore */ }
+      setTimeout(() => setRegisterStatus(""), 3000);
+    } catch {
+      setRegisterStatus("error");
+      setTimeout(() => setRegisterStatus(""), 3000);
+    } finally {
+      setRegisterLoading(false);
+    }
+  };
 
   const handleSaveQuickPlans = (plans) => {
     setSavedQuickPlans(plans);
@@ -286,6 +283,25 @@ function HomePage() {
               className="px-3 py-1.5 text-xs font-medium text-white bg-[#1a5c45] border border-[#2d7a5f] rounded-md hover:bg-[#226b52] transition"
             >
               Save Plan
+            </button>
+            <button
+              onClick={handleRegister}
+              disabled={registerLoading || registered.length === 0}
+              className={`px-3 py-1.5 text-xs font-medium rounded-md transition border ${
+                registerStatus === "registered"
+                  ? "bg-green-600 border-green-500 text-white"
+                  : registerStatus === "error"
+                  ? "bg-red-600 border-red-500 text-white"
+                  : "bg-[#b45309] border-[#d97706] text-white hover:bg-[#92400e] disabled:opacity-40"
+              }`}
+            >
+              {registerLoading
+                ? "Registering…"
+                : registerStatus === "registered"
+                ? "Registered!"
+                : registerStatus === "error"
+                ? "Failed"
+                : "Register"}
             </button>
           </div>
 

--- a/Frontend/src/pages/HomePage/HomePage.jsx
+++ b/Frontend/src/pages/HomePage/HomePage.jsx
@@ -38,6 +38,10 @@ function HomePage() {
   const [showAdminOverride, setShowAdminOverride] = useState(false);
   const [registerLoading, setRegisterLoading] = useState(false);
   const [registerStatus, setRegisterStatus] = useState("");
+  const [showLoadModal, setShowLoadModal] = useState(false);
+  const [savedPlans, setSavedPlans] = useState([]);
+  const [loadingPlans, setLoadingPlans] = useState(false);
+  const [loadingPlanName, setLoadingPlanName] = useState(null);
 
   const menuRef = useRef(null);
   const savePlanModalRef = useRef(null);
@@ -159,6 +163,43 @@ function HomePage() {
   };
 
 
+  const openLoadModal = async () => {
+    setShowLoadModal(true);
+    setLoadingPlans(true);
+    try {
+      const res = await fetch(`/api/plans/list?user=${encodeURIComponent(username)}`);
+      if (!res.ok) throw new Error();
+      const data = await res.json();
+      setSavedPlans(data.plans ?? []);
+    } catch {
+      setSavedPlans([]);
+    } finally {
+      setLoadingPlans(false);
+    }
+  };
+
+  const handleLoadPlan = async (plan) => {
+    setLoadingPlanName(plan.name);
+    try {
+      const params = new URLSearchParams({
+        user: username,
+        term: String(plan.termId),
+        name: plan.name,
+      });
+      const res = await fetch(`/api/plans/load?${params}`);
+      if (!res.ok) throw new Error();
+      const data = await res.json();
+      const loaded = (data.results ?? []).map(normalizeCourse);
+      if (loaded.length > 0) {
+        setRegistered(loaded);
+      }
+      setShowLoadModal(false);
+    } catch { /* ignore */ }
+    finally {
+      setLoadingPlanName(null);
+    }
+  };
+
   const handleRegister = async () => {
     if (registered.length === 0) return;
     setRegisterLoading(true);
@@ -277,6 +318,12 @@ function HomePage() {
               {savedQuickPlans.length > 0 && !showQuickPlanner && (
                 <span className="absolute -top-1 -right-1 w-2.5 h-2.5 bg-green-400 rounded-full border border-white" />
               )}
+            </button>
+            <button
+              onClick={openLoadModal}
+              className="px-3 py-1.5 text-xs font-medium text-white bg-[#475569] border border-[#64748b] rounded-md hover:bg-[#334155] transition"
+            >
+              Load Plan
             </button>
             <button
               onClick={openSavePlan}
@@ -404,6 +451,52 @@ function HomePage() {
                 </button>
               </div>
             </div>
+          </div>
+        </div>
+      )}
+
+      {showLoadModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div className="absolute inset-0 bg-black/40" onClick={() => setShowLoadModal(false)} />
+          <div
+            role="dialog"
+            aria-modal="true"
+            className="relative z-10 bg-white rounded-lg shadow-xl p-6 w-full max-w-md mx-4 max-h-[70vh] flex flex-col"
+          >
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-base font-semibold text-[#1e293b]">Load Plan</h2>
+              <button
+                onClick={() => setShowLoadModal(false)}
+                className="text-[#94a3b8] hover:text-[#475569] transition text-lg leading-none"
+              >
+                &times;
+              </button>
+            </div>
+
+            {loadingPlans ? (
+              <p className="text-sm text-[#64748b] text-center py-8">Loading plans…</p>
+            ) : savedPlans.length === 0 ? (
+              <p className="text-sm text-[#94a3b8] text-center py-8">No saved plans found.</p>
+            ) : (
+              <div className="flex flex-col gap-2 overflow-y-auto">
+                {savedPlans.map((p, i) => (
+                  <button
+                    key={`${p.name}-${p.termId}-${i}`}
+                    onClick={() => handleLoadPlan(p)}
+                    disabled={loadingPlanName === p.name}
+                    className="text-left px-4 py-3 rounded-lg border border-[#e2e8f0] bg-[#f8fafc] hover:border-[#0F3B2E] hover:bg-[#f0fdf4] transition disabled:opacity-50"
+                  >
+                    <span className="text-sm font-semibold text-[#1e293b]">{p.name}</span>
+                    <span className="ml-2 text-xs text-[#64748b]">
+                      Term {p.termId} · {p.courseCount} course{p.courseCount !== 1 ? "s" : ""}
+                    </span>
+                    {loadingPlanName === p.name && (
+                      <span className="ml-2 text-xs text-[#0F3B2E]">Loading…</span>
+                    )}
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
Implement the Register button (FR-32) that allows students to register their current schedule, making it the active plan visible to both the student on login and administrators. Also adds a Load Plan modal for students to browse and restore previously saved plans.

## Changes
- Add `register_courses()` and `load_registered_courses()` backend service functions using the `is_active` flag and a reserved `__registered__` plan name in the existing `plan` table
- Add new API endpoints: `POST /api/plans/register`, `GET /api/plans/registered`, `GET /api/admin/plans/registered`, `POST /api/admin/plans/register`
- Add `RegisterCourseList` and `AdminRegisterCourseList` Pydantic schemas
- Hide `__registered__` entries from plan list queries (`GET /api/plans/list`)
- Add Register button to HomePage header — sends current schedule to `POST /api/plans/register` with success/error feedback
- Change HomePage auto-load on login to fetch the registered schedule (`GET /api/plans/registered`) instead of the most recently updated plan
- Simplify AdminPage: student ID search now directly loads the student's registered schedule via `GET /api/admin/plans/registered`; Force Save updates it via `POST /api/admin/plans/register` (plan list picker removed)
- Add Load Plan button + modal to HomePage that fetches `GET /api/plans/list` and displays all saved plans for the student to browse and load into the current view

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Configuration

## Screenshots (if applicable)
<img width="1417" height="321" alt="Screenshot 2026-04-14 at 11 03 16 AM" src="https://github.com/user-attachments/assets/e22eb71f-5596-46dd-83ef-9847dd2bd97e" />



## Related Issue
Closes #84

## Deployment
- Deployment URL: 

## Additional Notes
- Registered schedules are stored in the `plan` table with `name = '__registered__'` and `is_active = true`, keeping the schema unchanged (no migration needed beyond the `updated_at` column added in `sprint3_issue#14`)
- The existing Save Plan / Load Plan flow is preserved as a separate feature from Register — students can save multiple named plans and load them, but only one registered schedule exists per student
- Admin Force Save now directly updates the student's registered schedule, which the student will see on their next login