### PR TITLE
Implement Quick Planner schedule generation

### DIFF
--- a/Backend/routers/generator.py
+++ b/Backend/routers/generator.py
@@ -46,8 +46,9 @@ def build_schedules(course_sections, index, current, results, limit=100):
             current.pop()
 
 def violates_constraints(time_slot, blocked_days, startTime):
+    start_min = time_slot.get("start_min")
     return (
-        (time_slot["start_min"] > startTime) or
+        (start_min is not None and start_min < startTime) or
         (time_slot["monday"] and "monday" in blocked_days) or
         (time_slot["tuesday"] and "tuesday" in blocked_days) or
         (time_slot["wednesday"] and "wednesday" in blocked_days) or

--- a/Backend/services/plan_service.py
+++ b/Backend/services/plan_service.py
@@ -151,6 +151,53 @@ def register_courses(user: str, course_ids: list[int]):
     conn = get_conn()
     try:
         cur = conn.cursor()
+
+        cur.execute(
+            "SELECT course_id FROM plan WHERE student_id = %s AND name = %s",
+            (user, REGISTERED_PLAN_NAME),
+        )
+        old_ids = [r["course_id"] for r in cur.fetchall()]
+
+        new_set = set(course_ids)
+        old_set = set(old_ids)
+        to_decrement = old_set - new_set
+        to_increment = new_set - old_set
+
+        if to_increment:
+            cur.execute(
+                """
+                SELECT course_id, max_reg, registered
+                FROM section
+                WHERE course_id = ANY(%s)
+                FOR UPDATE
+                """,
+                (list(to_increment),),
+            )
+            seat_rows = cur.fetchall()
+            full_courses = []
+            for sr in seat_rows:
+                avail = (sr["max_reg"] or 0) - (sr["registered"] or 0)
+                if avail <= 0:
+                    full_courses.append(sr["course_id"])
+            if full_courses:
+                conn.rollback()
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"No seats available for course(s): {full_courses}",
+                )
+
+        if to_decrement:
+            cur.execute(
+                "UPDATE section SET registered = registered - 1 WHERE course_id = ANY(%s)",
+                (list(to_decrement),),
+            )
+
+        if to_increment:
+            cur.execute(
+                "UPDATE section SET registered = registered + 1 WHERE course_id = ANY(%s)",
+                (list(to_increment),),
+            )
+
         cur.execute(
             "DELETE FROM plan WHERE student_id = %s AND name = %s",
             (user, REGISTERED_PLAN_NAME),
@@ -162,6 +209,8 @@ def register_courses(user: str, course_ids: list[int]):
                 (user, cid, REGISTERED_PLAN_NAME),
             )
         conn.commit()
+    except HTTPException:
+        raise
     except Exception as e:
         conn.rollback()
         raise HTTPException(status_code=500, detail=f"Failed to register: {e}")

--- a/Frontend/src/components/AdminOverride/AdminOverride.jsx
+++ b/Frontend/src/components/AdminOverride/AdminOverride.jsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from "react";
 import CourseSearch from "../CourseSearch/CourseSearch";
 import WeeklySchedule from "../WeeklySchedule/WeeklySchedule";
-import { detectConflicts } from "../../utils/courseUtils";
+import { detectConflicts, formatMeetingDaysForDisplay } from "../../utils/courseUtils";
 
 const TERM_OPTIONS = [
   { label: "Spring/Summer 2026", value: 202601 },
@@ -249,7 +249,7 @@ export default function AdminOverride({ onClose }) {
                           {course.name}
                         </p>
                         <p className="text-xs text-[#64748b] break-words whitespace-normal">
-                          {course.courseCode} · {course.credits} cr · {course.meetingDays} {course.meetingTime}
+                          {course.courseCode} · {course.credits} cr · {formatMeetingDaysForDisplay(course.meetingDays)} {course.meetingTime}
                         </p>
                       </div>
                       <button

--- a/Frontend/src/components/ComparePlans/ComparePlans.jsx
+++ b/Frontend/src/components/ComparePlans/ComparePlans.jsx
@@ -4,6 +4,7 @@ import {
   addMinutes,
   estimateDuration,
   timeToFloat,
+  formatMeetingDaysForDisplay,
 } from "../../utils/courseUtils";
 
 const DAYS = ["Mon", "Tue", "Wed", "Thu", "Fri"];
@@ -173,7 +174,7 @@ function PlanColumn({
             >
               <span className="font-bold text-[#0f172a]">{c.courseCode}</span>
               <span className="text-[#334155]">
-                {c.meetingDays} {c.meetingTime}
+                {formatMeetingDaysForDisplay(c.meetingDays)} {c.meetingTime}
               </span>
               {c.instructor && (
                 <span className="text-xs text-[#64748b] w-full sm:w-auto truncate">

--- a/Frontend/src/components/ComparePlans/ComparePlans.jsx
+++ b/Frontend/src/components/ComparePlans/ComparePlans.jsx
@@ -25,13 +25,6 @@ const COLORS = [
   "#7c3aed",
 ];
 
-function hashCrn(crn) {
-  const s = String(crn ?? "");
-  let h = 0;
-  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0;
-  return h;
-}
-
 function formatDisplayTime(time24) {
   const [h, m] = time24.split(":").map(Number);
   const period = h >= 12 ? "PM" : "AM";
@@ -49,6 +42,24 @@ function MiniWeekGrid({ plan, accentClass }) {
     timeLabels.push(`${display}:00 ${period}`);
   }
 
+  const colorByCourseKey = (() => {
+    const keys = Array.from(
+      new Set(
+        plan.map((course) =>
+          String(course.courseCode || course.crn || course.name || "").trim()
+        )
+      )
+    )
+      .filter(Boolean)
+      .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+
+    const map = new Map();
+    keys.forEach((key, index) => {
+      map.set(key, COLORS[index % COLORS.length]);
+    });
+    return map;
+  })();
+
   const getCourseBlocks = (day) => {
     return plan
       .filter((course) => {
@@ -56,22 +67,45 @@ function MiniWeekGrid({ plan, accentClass }) {
         return days.includes(day);
       })
       .map((course) => {
-        const start24 = parseTo24h(course.meetingTime);
-        const duration = estimateDuration(course.meetingDays);
-        const end24 = addMinutes(start24, duration);
+        const timeStr = (course.meetingTime || "").trim();
+        if (!timeStr || timeStr === "TBA") return null;
+
+        let start24;
+        let end24;
+
+        const parts = timeStr.split(" - ");
+        if (parts.length === 2) {
+          start24 = parseTo24h(parts[0].trim());
+          end24 = parseTo24h(parts[1].trim());
+        } else {
+          start24 = parseTo24h(timeStr);
+          const duration = estimateDuration(course.meetingDays);
+          end24 = addMinutes(start24, duration);
+        }
+
         const startFloat = timeToFloat(start24);
         const endFloat = timeToFloat(end24);
+        if (
+          Number.isNaN(startFloat) ||
+          Number.isNaN(endFloat) ||
+          endFloat <= startFloat
+        ) {
+          return null;
+        }
+
         const top = ((startFloat - START_HOUR) / HOURS_RANGE) * 100;
         const height = ((endFloat - startFloat) / HOURS_RANGE) * 100;
-        const colorIndex = hashCrn(course.crn) % COLORS.length;
+        const courseKey = String(course.courseCode || course.crn || course.name || "").trim();
+        const color = colorByCourseKey.get(courseKey) || COLORS[0];
         return {
           course,
           top,
           height,
-          color: COLORS[colorIndex],
+          color,
           start24,
         };
-      });
+      })
+      .filter(Boolean);
   };
 
   return (

--- a/Frontend/src/components/ComparePlans/ComparePlans.jsx
+++ b/Frontend/src/components/ComparePlans/ComparePlans.jsx
@@ -43,7 +43,7 @@ const SLOT_PX = 28;
 
 function MiniWeekGrid({ plan, accentClass }) {
   const timeLabels = [];
-  for (let hour = START_HOUR; hour <= END_HOUR; hour++) {
+  for (let hour = START_HOUR; hour < END_HOUR; hour++) {
     const period = hour >= 12 ? "PM" : "AM";
     const display = hour > 12 ? hour - 12 : hour === 0 ? 12 : hour;
     timeLabels.push(`${display}:00 ${period}`);

--- a/Frontend/src/components/CourseDetails/CourseDetails.jsx
+++ b/Frontend/src/components/CourseDetails/CourseDetails.jsx
@@ -1,3 +1,5 @@
+import { formatMeetingDaysForDisplay } from "../../utils/courseUtils";
+
 export default function CourseDetails({ course, onClose }) {
     if (!course) return null;
     return (
@@ -30,7 +32,7 @@ export default function CourseDetails({ course, onClose }) {
 
                 <p className="mb-3"><strong>Instructor / Meeting Times:</strong><br />
                     Instructor: {course.instructor}<br />
-                    {course.meetingDays} {course.meetingTime}<br />
+                    {formatMeetingDaysForDisplay(course.meetingDays)} {course.meetingTime}<br />
                      Main Campus | {course.building} | Room {course.room}
                 </p>
 

--- a/Frontend/src/components/CourseSearch/CourseSearch.jsx
+++ b/Frontend/src/components/CourseSearch/CourseSearch.jsx
@@ -44,7 +44,7 @@ function sortResults(results, sortBy, sortOrder) {
   });
 }
 
-export default function CourseSearch({ registered = [], onAddCourse, onRemoveCourse, conflicts = new Set(), bypassCreditLimit = false }) {
+export default function CourseSearch({ registered = [], onAddCourse, onRemoveCourse, conflicts = new Set(), bypassCreditLimit = false, scheduleTerm = "" }) {
   const [courseSubject, setCourseSubject] = useState("");
   const [courseNumber, setCourseNumber] = useState("");
   const [crnSearch, setCrnSearch] = useState("");
@@ -64,6 +64,12 @@ export default function CourseSearch({ registered = [], onAddCourse, onRemoveCou
   const [filterInstructor, setFilterInstructor] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
   const [conflictMessage, setConflictMessage] = useState("");
+
+  useEffect(() => {
+    if (scheduleTerm && TERM_MAP[scheduleTerm]) {
+      setTerm(scheduleTerm);
+    }
+  }, [scheduleTerm]);
 
   const totalCredits = registered.reduce((sum, c) => sum + (c.credits || 0), 0);
   const [selectedCourse, setSelectedCourse] = useState(null);
@@ -101,6 +107,11 @@ export default function CourseSearch({ registered = [], onAddCourse, onRemoveCou
   }, [selectedCourse]);
 
   const handleSearch = async () => {
+    if (!term) {
+      setErrorMessage("Please select a semester before searching.");
+      return;
+    }
+
     setHasSearched(true);
     setLoading(true);
     setErrorMessage("");
@@ -113,10 +124,9 @@ export default function CourseSearch({ registered = [], onAddCourse, onRemoveCou
 
       const q = crn || num || subj;
 
-      const params = new URLSearchParams({ limit: "200" });
-      if (q) params.set("q", q);
       const termId = TERM_MAP[term];
-      if (termId) params.set("term_id", termId);
+      const params = new URLSearchParams({ limit: "200", term_id: termId });
+      if (q) params.set("q", q);
 
       const res = await fetch(`/api/courses/search?${params}`);
       if (!res.ok) throw new Error(`Server error: ${res.status}`);
@@ -230,7 +240,7 @@ export default function CourseSearch({ registered = [], onAddCourse, onRemoveCou
             aria-label="Select term"
             className="sm:w-52 px-3 py-2 border border-[#e2e8f0] rounded-md text-sm text-[#334155] bg-white outline-none focus:border-[#0F3B2E] focus:ring-2 focus:ring-[#0F3B2E]/10 transition"
           >
-            <option value="">All Semesters</option>
+            <option value="">Select Semester</option>
             <option value="Spring/Summer 2026">Spring/Summer 2026</option>
             <option value="Fall 2026">Fall 2026</option>
           </select>
@@ -268,7 +278,7 @@ export default function CourseSearch({ registered = [], onAddCourse, onRemoveCou
             />
             <button
               onClick={handleSearch}
-              disabled={loading}
+              disabled={loading || !term}
               className="px-4 py-2 bg-[#0F3B2E] hover:bg-[#0a2a20] disabled:opacity-50 text-white text-sm font-medium rounded-md transition whitespace-nowrap"
             >
               {loading ? "Searching…" : "Search"}

--- a/Frontend/src/components/CourseSearch/CourseSearch.jsx
+++ b/Frontend/src/components/CourseSearch/CourseSearch.jsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useRef, useEffect } from "react";
 import ErrorMessage from "../ErrorMessage/ErrorMessage";
 import CourseDetails from "../CourseDetails/CourseDetails";
-import { findConflictingCourses } from "../../utils/courseUtils";
+import { findConflictingCourses, formatMeetingDaysForDisplay } from "../../utils/courseUtils";
 import AvailableSeats from "../AvailableSeats/AvailableSeats";
 
 const TERM_MAP = {
@@ -16,6 +16,13 @@ const SORT_OPTIONS = [
 ];
 
 const ALL_DAYS = ["M", "T", "W", "R", "F"];
+const DAY_FILTER_LABELS = {
+  M: "M",
+  T: "TU",
+  W: "W",
+  R: "TR",
+  F: "F",
+};
 
 function normalizeCourse(raw) {
   return {
@@ -289,7 +296,7 @@ export default function CourseSearch({ registered = [], onAddCourse, onRemoveCou
                         : "bg-white text-[#475569] border-[#e2e8f0] hover:border-[#0F3B2E]"
                     }`}
                   >
-                    {day}
+                    {DAY_FILTER_LABELS[day] || day}
                   </button>
                 ))}
               </div>
@@ -392,7 +399,7 @@ export default function CourseSearch({ registered = [], onAddCourse, onRemoveCou
                             </button>
 
                             <div className="flex flex-wrap gap-x-4 gap-y-1">
-                              <span className="text-sm text-[#475569]">📅 {course.meetingDays} · {course.meetingTime}</span>
+                              <span className="text-sm text-[#475569]">📅 {formatMeetingDaysForDisplay(course.meetingDays)} · {course.meetingTime}</span>
                               <span className="text-sm text-[#475569]">🎓 {course.credits} credits</span>
                               <span className="text-sm text-[#475569]">👤 {course.instructor}</span>
                               <span className="text-sm text-[#475569]">📍 {course.location}</span>

--- a/Frontend/src/components/ExportButton/ExportButton.jsx
+++ b/Frontend/src/components/ExportButton/ExportButton.jsx
@@ -2,7 +2,7 @@ import html2canvas from "html2canvas";
 import { jsPDF } from "jspdf";
 import {
     parseMeetingDays, parseTo24h, addMinutes,
-    estimateDuration, timeToFloat,
+    estimateDuration, timeToFloat, formatMeetingDaysForDisplay,
 } from "../../utils/courseUtils";
 
 const DAYS = ["Mon", "Tue", "Wed", "Thu", "Fri"];
@@ -125,7 +125,7 @@ export default function ExportButton({ registered, conflicts = new Set() }) {
             }, course.name));
             item.appendChild(el("div", {
                 fontSize: "8px", color: "#64748b", marginTop: "2px",
-            }, `${course.credits} cr · ${course.meetingDays} ${course.meetingTime}${location ? ` · ${location}` : ""}`));
+            }, `${course.credits} cr · ${formatMeetingDaysForDisplay(course.meetingDays)} ${course.meetingTime}${location ? ` · ${location}` : ""}`));
             courseList.appendChild(item);
         });
         leftPanel.appendChild(courseList);

--- a/Frontend/src/components/ExportButton/ExportButton.jsx
+++ b/Frontend/src/components/ExportButton/ExportButton.jsx
@@ -16,8 +16,9 @@ const COLORS = [
 ];
 
 function hashCrn(crn) {
+    const s = String(crn ?? "");
     let h = 0;
-    for (let i = 0; i < crn.length; i++) h = (h * 31 + crn.charCodeAt(i)) >>> 0;
+    for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0;
     return h;
 }
 
@@ -49,6 +50,114 @@ export default function ExportButton({ registered, conflicts = new Set() }) {
         const TIME_COL_W = 44;
         const GRID_HEADER_H = 24;
         const totalCredits = registered.reduce((s, c) => s + (c.credits || 0), 0);
+
+        const getCourseBlocks = (day) => {
+            const rawBlocks = registered
+                .filter((course) => {
+                    const parsed = parseMeetingDays(course.meetingDays || course.days || "");
+                    return parsed.includes(day);
+                })
+                .map((course) => {
+                    let startFloat;
+                    let endFloat;
+                    let start24;
+
+                    const timeStr = (course.meetingTime || course.time || "").trim();
+                    if (!timeStr || timeStr === "TBA") return null;
+
+                    const parts = timeStr.split(" - ");
+                    if (parts.length === 2) {
+                        start24 = parseTo24h(parts[0].trim());
+                        const end24 = parseTo24h(parts[1].trim());
+                        startFloat = timeToFloat(start24);
+                        endFloat = timeToFloat(end24);
+                    } else {
+                        start24 = parseTo24h(timeStr);
+                        startFloat = timeToFloat(start24);
+                        if (Number.isNaN(startFloat)) return null;
+                        const durationHours = estimateDuration(course.meetingDays || course.days || "") / 60;
+                        endFloat = startFloat + durationHours;
+                    }
+
+                    if (
+                        Number.isNaN(startFloat) ||
+                        Number.isNaN(endFloat) ||
+                        endFloat <= startFloat
+                    ) {
+                        return null;
+                    }
+
+                    const top = ((startFloat - START_HOUR) / HOURS_RANGE) * 100;
+                    const height = ((endFloat - startFloat) / HOURS_RANGE) * 100;
+                    const color = conflicts.has(course.crn)
+                        ? "#dc2626"
+                        : COLORS[hashCrn(course.crn || course.courseCode || course.name) % COLORS.length];
+                    const location = [course.building, course.room].filter(Boolean).join(" ");
+
+                    return {
+                        course,
+                        top,
+                        height,
+                        startFloat,
+                        endFloat,
+                        color,
+                        start24,
+                        location,
+                    };
+                })
+                .filter(Boolean);
+
+            const sortedBlocks = [...rawBlocks].sort(
+                (a, b) => a.startFloat - b.startFloat || a.endFloat - b.endFloat
+            );
+
+            const layoutGroup = (group) => {
+                const active = [];
+                const placed = [];
+                let maxColumns = 0;
+
+                group.forEach((block) => {
+                    for (let i = active.length - 1; i >= 0; i--) {
+                        if (active[i].endFloat <= block.startFloat) active.splice(i, 1);
+                    }
+
+                    const used = new Set(active.map((item) => item.columnIndex));
+                    let columnIndex = 0;
+                    while (used.has(columnIndex)) columnIndex += 1;
+
+                    active.push({ endFloat: block.endFloat, columnIndex });
+                    maxColumns = Math.max(maxColumns, columnIndex + 1);
+                    placed.push({ ...block, columnIndex });
+                });
+
+                return placed.map((block) => ({ ...block, overlapColumns: maxColumns }));
+            };
+
+            const laidOut = [];
+            let group = [];
+            let groupEnd = -Infinity;
+
+            sortedBlocks.forEach((block) => {
+                if (!group.length) {
+                    group = [block];
+                    groupEnd = block.endFloat;
+                    return;
+                }
+
+                if (block.startFloat < groupEnd) {
+                    group.push(block);
+                    groupEnd = Math.max(groupEnd, block.endFloat);
+                    return;
+                }
+
+                laidOut.push(...layoutGroup(group));
+                group = [block];
+                groupEnd = block.endFloat;
+            });
+
+            if (group.length) laidOut.push(...layoutGroup(group));
+            return laidOut;
+        };
 
         const container = el("div", {
             position: "absolute", top: "-9999px", left: "-9999px",
@@ -210,21 +319,14 @@ export default function ExportButton({ registered, conflicts = new Set() }) {
                 }));
             }
 
-            registered.forEach((course) => {
-                if (!parseMeetingDays(course.meetingDays).includes(day)) return;
-
-                const start24 = parseTo24h(course.meetingTime);
-                const end24 = addMinutes(start24, estimateDuration(course.meetingDays));
-                const top = ((timeToFloat(start24) - START_HOUR) / HOURS_RANGE) * 100;
-                const height = Math.max(((timeToFloat(end24) - timeToFloat(start24)) / HOURS_RANGE) * 100, 3);
-                const color = conflicts.has(course.crn)
-                    ? "#dc2626"
-                    : COLORS[hashCrn(course.crn) % COLORS.length];
-                const location = [course.building, course.room].filter(Boolean).join(" ");
-
+            const blocks = getCourseBlocks(day);
+            blocks.forEach(({ course, top, height, color, start24, location, columnIndex, overlapColumns }) => {
                 const block = el("div", {
-                    position: "absolute", left: "1px", right: "1px",
-                    top: `${top}%`, height: `${height}%`,
+                    position: "absolute",
+                    top: `${top}%`,
+                    height: `${Math.max(height, 3)}%`,
+                    left: `calc(${(columnIndex * 100) / overlapColumns}% + 1px)`,
+                    width: `calc(${100 / overlapColumns}% - 2px)`,
                     backgroundColor: color, borderRadius: "3px",
                     overflow: "hidden", padding: "2px 3px", boxSizing: "border-box",
                 });

--- a/Frontend/src/components/MySchedule/MySchedule.jsx
+++ b/Frontend/src/components/MySchedule/MySchedule.jsx
@@ -1,4 +1,5 @@
 import { forwardRef } from "react";
+import { formatMeetingDaysForDisplay } from "../../utils/courseUtils";
 
 function MySchedule({ courses, onRemove, totalCredits }, ref) {
   return (
@@ -32,7 +33,7 @@ function MySchedule({ courses, onRemove, totalCredits }, ref) {
                   {course.name}
                 </p>
                 <p className="text-xs text-[#64748b] break-words whitespace-normal">
-                  {course.courseCode} · {course.credits} cr · {course.meetingDays} {course.meetingTime}
+                  {course.courseCode} · {course.credits} cr · {formatMeetingDaysForDisplay(course.meetingDays)} {course.meetingTime}
                 </p>
               </div>
               <button

--- a/Frontend/src/components/QuickPlanner/QuickPlanner.jsx
+++ b/Frontend/src/components/QuickPlanner/QuickPlanner.jsx
@@ -1,11 +1,4 @@
 import { useState, useMemo, useCallback, useEffect, useRef } from "react";
-import {
-  parseMeetingDays,
-  parseTo24h,
-  timeToFloat,
-  estimateDuration,
-  formatMeetingDaysForDisplay,
-} from "../../utils/courseUtils";
 import ComparePlans from "../ComparePlans/ComparePlans";
 
 const TERM_MAP = {
@@ -15,6 +8,13 @@ const TERM_MAP = {
 
 const PLANS_PER_PAGE = 3;
 const MAX_PLANS = 50;
+const NO_MORNING_START_TIME = 12 * 60;
+const NO_TIME_CONSTRAINT = 0;
+const MAX_COMBINATIONS = 40;
+
+function getDefaultPlannerGroups() {
+  return [{ id: 1, name: "Group 1", courseOptions: {} }];
+}
 
 function normalizeCourse(raw) {
   return {
@@ -25,41 +25,48 @@ function normalizeCourse(raw) {
   };
 }
 
-function getTimeRange(course) {
-  const timeStr = course.meetingTime || course.time || "";
-  if (!timeStr || timeStr === "TBA") return null;
-
-  const parts = timeStr.split(" - ");
-  if (parts.length === 2) {
-    const s = timeToFloat(parseTo24h(parts[0].trim()));
-    const e = timeToFloat(parseTo24h(parts[1].trim()));
-    if (!isNaN(s) && !isNaN(e)) return { start: s, end: e };
+function getGroupMeta(course) {
+  const subject = String(course.subject || "").trim().toUpperCase();
+  const courseNumber = String(course.courseNumber ?? course.number ?? "").trim();
+  if (subject && courseNumber) {
+    return {
+      key: `${subject}-${courseNumber}`,
+      label: `${subject}${courseNumber}`,
+    };
   }
 
-  const s = timeToFloat(parseTo24h(timeStr));
-  if (!isNaN(s)) {
-    return { start: s, end: s + estimateDuration(course.meetingDays) / 60 };
+  const courseCode = String(course.courseCode || "").trim();
+  const matched = courseCode.match(/^([A-Za-z]+)\s*([0-9A-Za-z]+)$/);
+  if (matched) {
+    const parsedSubject = matched[1].toUpperCase();
+    const parsedNumber = matched[2];
+    return {
+      key: `${parsedSubject}-${parsedNumber}`,
+      label: `${parsedSubject}${parsedNumber}`,
+    };
   }
-  return null;
+
+  return {
+    key: courseCode || String(course.crn || Math.random()),
+    label: courseCode || "Course",
+  };
 }
 
-function sectionsOverlap(a, b) {
-  const daysA = parseMeetingDays(a.meetingDays);
-  const daysB = parseMeetingDays(b.meetingDays);
-  if (!daysA.some((d) => daysB.includes(d))) return false;
-  const ra = getTimeRange(a);
-  const rb = getTimeRange(b);
-  if (!ra || !rb) return false;
-  return ra.start < rb.end && rb.start < ra.end;
-}
-
-function comboHasConflict(combo) {
-  for (let i = 0; i < combo.length; i++) {
-    for (let j = i + 1; j < combo.length; j++) {
-      if (sectionsOverlap(combo[i], combo[j])) return true;
-    }
+function parseCourseIdentifier(section) {
+  const subject = String(section.subject || "").trim();
+  const courseNumber = String(section.courseNumber ?? section.number ?? "").trim();
+  if (subject && courseNumber) {
+    return { subject: subject.toUpperCase(), course_number: courseNumber };
   }
-  return false;
+
+  const courseCode = String(section.courseCode || "").trim();
+  const matched = courseCode.match(/^([A-Za-z]+)\s*([0-9A-Za-z]+)$/);
+  if (!matched) return null;
+
+  return {
+    subject: matched[1].toUpperCase(),
+    course_number: matched[2],
+  };
 }
 
 function cartesianProduct(arrays) {
@@ -69,19 +76,104 @@ function cartesianProduct(arrays) {
   );
 }
 
+function buildConstraints(preferNoFriday, preferNoMorning) {
+  const days = [];
+  if (preferNoFriday) days.push("friday");
+
+  const startTime = preferNoMorning ? NO_MORNING_START_TIME : NO_TIME_CONSTRAINT;
+  return { days, startTime };
+}
+
+function buildSectionLookup(plannerGroups) {
+  const byCourseId = new Map();
+
+  plannerGroups.forEach((group) => {
+    Object.values(group.courseOptions).forEach((sections) => {
+      sections.forEach((section) => {
+        if (section.courseId) byCourseId.set(section.courseId, section);
+      });
+    });
+  });
+
+  return { byCourseId };
+}
+
+function normalizeWeekDaysFromSlot(slot) {
+  let days = "";
+  if (slot?.monday) days += "M";
+  if (slot?.tuesday) days += "T";
+  if (slot?.wednesday) days += "W";
+  if (slot?.thursday) days += "R";
+  if (slot?.friday) days += "F";
+  return days || "TBA";
+}
+
+function toDisplayTime(totalMin) {
+  if (typeof totalMin !== "number") return "";
+  const h24 = Math.floor(totalMin / 60);
+  const mm = totalMin % 60;
+  const period = h24 >= 12 ? "PM" : "AM";
+  const h12 = h24 % 12 === 0 ? 12 : h24 % 12;
+  return `${h12}:${String(mm).padStart(2, "0")} ${period}`;
+}
+
+function normalizeMeetingTimeFromSlot(slot) {
+  if (!slot || typeof slot.start_min !== "number" || typeof slot.end_min !== "number") {
+    return "TBA";
+  }
+  return `${toDisplayTime(slot.start_min)} - ${toDisplayTime(slot.end_min)}`;
+}
+
+function hydrateSchedules(rawSchedules, plannerGroups) {
+  const { byCourseId } = buildSectionLookup(plannerGroups);
+  return (rawSchedules || [])
+    .map((schedule) =>
+      schedule
+        .map((item) => {
+          const matched = byCourseId.get(item.course_id);
+          if (matched) return matched;
+
+          return {
+            crn: `gen-${item.course_id}-${item.time_slot?.start_min ?? "na"}-${item.time_slot?.end_min ?? "na"}`,
+            courseId: item.course_id,
+            courseCode: `COURSE ${item.course_id}`,
+            name: `Course ${item.course_id}`,
+            instructor: "TBA",
+            meetingDays: normalizeWeekDaysFromSlot(item.time_slot),
+            meetingTime: normalizeMeetingTimeFromSlot(item.time_slot),
+            credits: 0,
+          };
+        })
+        .filter(Boolean)
+    )
+    .filter((schedule) => schedule.length > 0);
+}
+
 export default function QuickPlanner({
   onClose,
   onApplyPlan,
   savedPlans,
   onSavePlans,
+  savedPlannerState,
+  onSavePlannerState,
 }) {
-  const [searchQuery, setSearchQuery] = useState("");
+  const [courseSubject, setCourseSubject] = useState("");
+  const [courseNumber, setCourseNumber] = useState("");
+  const [crnSearch, setCrnSearch] = useState("");
   const [term, setTerm] = useState("");
   const [searchResults, setSearchResults] = useState([]);
   const [searchLoading, setSearchLoading] = useState(false);
-  const [selectedGroups, setSelectedGroups] = useState({});
-  const [preferNoFriday, setPreferNoFriday] = useState(false);
-  const [preferNoMorning, setPreferNoMorning] = useState(false);
+  const [plannerGroups, setPlannerGroups] = useState(
+    Array.isArray(savedPlannerState?.plannerGroups) && savedPlannerState.plannerGroups.length > 0
+      ? savedPlannerState.plannerGroups
+      : getDefaultPlannerGroups()
+  );
+  const [activeGroupId, setActiveGroupId] = useState(
+    Number.isInteger(savedPlannerState?.activeGroupId) ? savedPlannerState.activeGroupId : 1
+  );
+  const [selectedSearchKeys, setSelectedSearchKeys] = useState({});
+  const [preferNoFriday, setPreferNoFriday] = useState(!!savedPlannerState?.preferNoFriday);
+  const [preferNoMorning, setPreferNoMorning] = useState(!!savedPlannerState?.preferNoMorning);
   const [plans, setPlans] = useState(savedPlans || []);
   const [pageIndex, setPageIndex] = useState(0);
   const [generating, setGenerating] = useState(false);
@@ -91,6 +183,27 @@ export default function QuickPlanner({
   const [compareSelection, setCompareSelection] = useState([]);
   const [showCompare, setShowCompare] = useState(false);
   const quickPlannerModalRef = useRef(null);
+
+  useEffect(() => {
+    if (!Array.isArray(plannerGroups) || plannerGroups.length === 0) {
+      setPlannerGroups(getDefaultPlannerGroups());
+      setActiveGroupId(1);
+      return;
+    }
+
+    if (!plannerGroups.some((group) => group.id === activeGroupId)) {
+      setActiveGroupId(plannerGroups[0].id);
+    }
+  }, [plannerGroups, activeGroupId]);
+
+  useEffect(() => {
+    onSavePlannerState?.({
+      plannerGroups,
+      activeGroupId,
+      preferNoFriday,
+      preferNoMorning,
+    });
+  }, [plannerGroups, activeGroupId, preferNoFriday, preferNoMorning, onSavePlannerState]);
 
   useEffect(() => {
     const modalEl = quickPlannerModalRef.current;
@@ -124,17 +237,35 @@ export default function QuickPlanner({
   }, [onClose]);
 
   const handleSearch = async () => {
-    if (!searchQuery.trim()) return;
     setSearchLoading(true);
     try {
+      const subj = courseSubject.trim();
+      const num = courseNumber.trim();
+      const crn = crnSearch.trim();
+      const q = crn || num || subj;
+
       const params = new URLSearchParams({ limit: "200" });
-      params.set("q", searchQuery.trim());
+      if (q) params.set("q", q);
       const termId = TERM_MAP[term];
       if (termId) params.set("term_id", termId);
       const res = await fetch(`/api/courses/search?${params}`);
       if (!res.ok) throw new Error("Search failed");
       const data = await res.json();
-      setSearchResults((data.results ?? []).map(normalizeCourse));
+      let results = (data.results ?? []).map(normalizeCourse);
+      if (subj) {
+        results = results.filter((c) =>
+          (c.subject || "").toLowerCase().includes(subj.toLowerCase())
+        );
+      }
+      if (num) {
+        results = results.filter((c) =>
+          (c.courseNumber ?? c.number ?? "").toLowerCase().includes(num.toLowerCase())
+        );
+      }
+      if (crn) {
+        results = results.filter((c) => (c.crn || "").includes(crn));
+      }
+      setSearchResults(results);
     } catch {
       setSearchResults([]);
     } finally {
@@ -145,9 +276,11 @@ export default function QuickPlanner({
   const groupedResults = useMemo(() => {
     const groups = {};
     for (const c of searchResults) {
-      const key = c.courseCode;
+      const { key, label } = getGroupMeta(c);
       if (!groups[key])
         groups[key] = {
+          key,
+          shortLabel: label,
           courseCode: key,
           name: c.name,
           credits: c.credits,
@@ -158,63 +291,140 @@ export default function QuickPlanner({
     return Object.values(groups);
   }, [searchResults]);
 
-  const toggleGroup = (group) => {
-    setSelectedGroups((prev) => {
+  const toggleSearchCourse = (group) => {
+    setSelectedSearchKeys((prev) => {
       const next = { ...prev };
       if (next[group.courseCode]) delete next[group.courseCode];
-      else next[group.courseCode] = group.sections;
+      else next[group.courseCode] = true;
       return next;
     });
   };
 
-  const removeGroup = (code) => {
-    setSelectedGroups((prev) => {
-      const next = { ...prev };
-      delete next[code];
+  const addGroup = () => {
+    setPlannerGroups((prev) => {
+      const nextId = (prev[prev.length - 1]?.id ?? 0) + 1;
+      const next = [...prev, { id: nextId, name: `Group ${nextId}`, courseOptions: {} }];
+      setActiveGroupId(nextId);
       return next;
     });
   };
 
-  const handleGenerate = useCallback(() => {
-    const groups = Object.values(selectedGroups);
-    if (groups.length === 0) return;
+  const removeGroup = (groupId) => {
+    setPlannerGroups((prev) => {
+      const next = prev.filter((g) => g.id !== groupId);
+      if (next.length === 0) {
+        setActiveGroupId(1);
+        return [{ id: 1, name: "Group 1", courseOptions: {} }];
+      }
+      if (!next.some((g) => g.id === activeGroupId)) {
+        setActiveGroupId(next[0].id);
+      }
+      return next;
+    });
+  };
+
+  const addSelectedToActiveGroup = () => {
+    const selectedKeys = Object.keys(selectedSearchKeys);
+    if (selectedKeys.length === 0) return;
+
+    const groupMap = Object.fromEntries(groupedResults.map((g) => [g.courseCode, g.sections]));
+    setPlannerGroups((prev) =>
+      prev.map((group) => {
+        if (group.id !== activeGroupId) return group;
+        const nextOptions = { ...group.courseOptions };
+        selectedKeys.forEach((key) => {
+          const sections = groupMap[key];
+          if (sections?.length) nextOptions[key] = sections;
+        });
+        return { ...group, courseOptions: nextOptions };
+      })
+    );
+    setSelectedSearchKeys({});
+  };
+
+  const removeCourseFromGroup = (groupId, courseKey) => {
+    setPlannerGroups((prev) =>
+      prev.map((group) => {
+        if (group.id !== groupId) return group;
+        const nextOptions = { ...group.courseOptions };
+        delete nextOptions[courseKey];
+        return { ...group, courseOptions: nextOptions };
+      })
+    );
+  };
+
+  const handleGenerate = useCallback(async () => {
+    const configuredGroups = plannerGroups.filter(
+      (group) => Object.keys(group.courseOptions).length > 0
+    );
+    if (configuredGroups.length === 0) return;
+
+    const optionSets = configuredGroups.map((group) =>
+      Object.entries(group.courseOptions)
+        .map(([courseKey, sections]) => {
+          const identifier = parseCourseIdentifier(sections[0]);
+          if (!identifier) return null;
+          return { ...identifier, courseKey, groupId: group.id };
+        })
+        .filter(Boolean)
+    );
+    if (optionSets.some((set) => set.length === 0)) return;
+
+    const combinations = cartesianProduct(optionSets).slice(0, MAX_COMBINATIONS);
+    if (combinations.length === 0) return;
+
     setGenerating(true);
+    try {
+      const constraints = buildConstraints(preferNoFriday, preferNoMorning);
+      const mergedPlans = [];
+      const seenSchedules = new Set();
 
-    setTimeout(() => {
-      const combos = cartesianProduct(groups);
-      let valid = [];
-      for (const combo of combos) {
-        if (valid.length >= MAX_PLANS) break;
-        if (!comboHasConflict(combo)) valid.push(combo);
+      for (const combination of combinations) {
+        if (mergedPlans.length >= MAX_PLANS) break;
+        const response = await fetch("/api/generator/generate-schedules", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            courses: combination.map(({ subject, course_number }) => ({
+              subject,
+              course_number,
+            })),
+            days: constraints.days,
+            startTime: constraints.startTime,
+          }),
+        });
+        if (!response.ok) continue;
+        const data = await response.json();
+        const hydrated = hydrateSchedules(data.schedules, plannerGroups);
+        for (const schedule of hydrated) {
+          const signature = schedule
+            .map((c) => String(c.crn || c.courseId || c.courseCode))
+            .sort()
+            .join("|");
+          if (seenSchedules.has(signature)) continue;
+          seenSchedules.add(signature);
+          mergedPlans.push(schedule);
+          if (mergedPlans.length >= MAX_PLANS) break;
+        }
       }
-
-      if (preferNoFriday) {
-        const pref = valid.filter(
-          (c) => !c.some((x) => (x.meetingDays || "").includes("F"))
-        );
-        if (pref.length > 0) valid = pref;
-      }
-
-      if (preferNoMorning) {
-        const pref = valid.filter(
-          (c) =>
-            !c.some((x) => {
-              const r = getTimeRange(x);
-              return r && r.start < 10;
-            })
-        );
-        if (pref.length > 0) valid = pref;
-      }
+      const valid = mergedPlans.slice(0, MAX_PLANS);
 
       setPlans(valid);
       setPageIndex(0);
       setHasGenerated(true);
-      setGenerating(false);
       setCompareSelection([]);
       setShowCompare(false);
       onSavePlans?.(valid);
-    }, 50);
-  }, [selectedGroups, preferNoFriday, preferNoMorning, onSavePlans]);
+    } catch {
+      setPlans([]);
+      setHasGenerated(true);
+      setCompareSelection([]);
+      setShowCompare(false);
+      onSavePlans?.([]);
+    } finally {
+      setGenerating(false);
+    }
+  }, [plannerGroups, preferNoFriday, preferNoMorning, onSavePlans]);
 
   const toggleCompareIndex = useCallback((globalIdx) => {
     setCompareSelection((prev) => {
@@ -231,7 +441,9 @@ export default function QuickPlanner({
   const totalPages = Math.ceil(plans.length / PLANS_PER_PAGE);
   const startIdx = pageIndex * PLANS_PER_PAGE;
   const visiblePlans = plans.slice(startIdx, startIdx + PLANS_PER_PAGE);
-  const selectedCount = Object.keys(selectedGroups).length;
+  const configuredGroupCount = plannerGroups.filter(
+    (group) => Object.keys(group.courseOptions).length > 0
+  ).length;
 
   const handleRegenerate = () => {
     setPageIndex((prev) => (prev + 1 < totalPages ? prev + 1 : 0));
@@ -280,7 +492,7 @@ export default function QuickPlanner({
               1. Select Required Courses
             </h3>
 
-            <div className="flex gap-2 mb-3">
+            <div className="flex flex-wrap gap-2 mb-3">
               <select
                 value={term}
                 onChange={(e) => setTerm(e.target.value)}
@@ -295,14 +507,34 @@ export default function QuickPlanner({
                 ))}
               </select>
               <input
-                id="quick-planner-search-input"
+                id="quick-planner-subject-input"
                 type="text"
-                placeholder="Search courses (e.g. CSC, MAT)..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Course Subject"
+                value={courseSubject}
+                onChange={(e) => setCourseSubject(e.target.value)}
                 onKeyDown={(e) => e.key === "Enter" && handleSearch()}
-                aria-label="Search courses"
-                className="flex-1 px-3 py-2 border border-[#e2e8f0] rounded-md text-sm text-[#334155] outline-none focus:border-[#0F3B2E] focus:ring-2 focus:ring-[#0F3B2E]/10 transition"
+                aria-label="Course subject"
+                className="flex-1 min-w-[9rem] px-3 py-2 border border-[#e2e8f0] rounded-md text-sm text-[#334155] outline-none focus:border-[#0F3B2E] focus:ring-2 focus:ring-[#0F3B2E]/10 transition"
+              />
+              <input
+                id="quick-planner-number-input"
+                type="text"
+                placeholder="Course Number"
+                value={courseNumber}
+                onChange={(e) => setCourseNumber(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+                aria-label="Course number"
+                className="flex-1 min-w-[9rem] px-3 py-2 border border-[#e2e8f0] rounded-md text-sm text-[#334155] outline-none focus:border-[#0F3B2E] focus:ring-2 focus:ring-[#0F3B2E]/10 transition"
+              />
+              <input
+                id="quick-planner-crn-input"
+                type="text"
+                placeholder="CRN"
+                value={crnSearch}
+                onChange={(e) => setCrnSearch(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+                aria-label="CRN"
+                className="flex-1 min-w-[8rem] px-3 py-2 border border-[#e2e8f0] rounded-md text-sm text-[#334155] outline-none focus:border-[#0F3B2E] focus:ring-2 focus:ring-[#0F3B2E]/10 transition"
               />
               <button
                 onClick={handleSearch}
@@ -313,6 +545,35 @@ export default function QuickPlanner({
               </button>
             </div>
 
+            <div className="flex flex-wrap items-center gap-2 mb-3">
+              <select
+                value={activeGroupId}
+                onChange={(e) => setActiveGroupId(Number(e.target.value))}
+                className="px-3 py-2 border border-[#e2e8f0] rounded-md text-sm text-[#334155] bg-white outline-none focus:border-[#0F3B2E] focus:ring-2 focus:ring-[#0F3B2E]/10 transition"
+              >
+                {plannerGroups.map((group) => (
+                  <option key={group.id} value={group.id}>
+                    {group.name}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                onClick={addSelectedToActiveGroup}
+                disabled={Object.keys(selectedSearchKeys).length === 0}
+                className="px-3 py-2 bg-[#1e3a5f] hover:bg-[#152a45] disabled:opacity-40 text-white text-sm font-medium rounded-md transition"
+              >
+                Add selected to {plannerGroups.find((g) => g.id === activeGroupId)?.name || "group"}
+              </button>
+              <button
+                type="button"
+                onClick={addGroup}
+                className="px-3 py-2 border border-[#0F3B2E] text-[#0F3B2E] text-sm font-medium rounded-md hover:bg-[#f0fdf4] transition"
+              >
+                New group
+              </button>
+            </div>
+
             {/* Search results grouped by courseCode */}
             {groupedResults.length > 0 && (
               <div className="border border-[#e2e8f0] rounded-lg max-h-48 overflow-y-auto divide-y divide-[#f1f5f9]">
@@ -320,18 +581,18 @@ export default function QuickPlanner({
                   <label
                     key={g.courseCode}
                     className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer hover:bg-[#f8fafc] transition ${
-                      selectedGroups[g.courseCode] ? "bg-[#f0fdf4]" : ""
+                      selectedSearchKeys[g.courseCode] ? "bg-[#f0fdf4]" : ""
                     }`}
                   >
                     <input
                       type="checkbox"
-                      checked={!!selectedGroups[g.courseCode]}
-                      onChange={() => toggleGroup(g)}
+                      checked={!!selectedSearchKeys[g.courseCode]}
+                      onChange={() => toggleSearchCourse(g)}
                       className="w-4 h-4 accent-[#0F3B2E] flex-shrink-0"
                     />
                     <div className="flex-1 min-w-0">
                       <span className="text-sm font-medium text-[#1e293b]">
-                        {g.courseCode}
+                        {g.shortLabel || g.courseCode}
                       </span>
                       <span className="text-sm text-[#64748b] ml-2">
                         {g.name}
@@ -346,29 +607,76 @@ export default function QuickPlanner({
               </div>
             )}
 
-            {/* Selected course tags */}
-            {selectedCount > 0 && (
-              <div className="flex flex-wrap gap-2 mt-3">
-                {Object.keys(selectedGroups).map((code) => (
-                  <span
-                    key={code}
-                    className="inline-flex items-center gap-1 px-2.5 py-1 bg-[#0F3B2E] text-white text-xs font-medium rounded-full"
-                  >
-                    {code}
-                    <button
-                      onClick={() => removeGroup(code)}
-                      className="ml-0.5 hover:text-red-200 transition"
+            {/* User-defined groups */}
+            {plannerGroups.length > 0 && (
+              <div className="space-y-2 mt-3">
+                {plannerGroups.map((group) => {
+                  const entries = Object.entries(group.courseOptions);
+                  const isActiveGroup = group.id === activeGroupId;
+                  return (
+                    <div
+                      key={group.id}
+                      onClick={() => setActiveGroupId(group.id)}
+                      className={`border-2 rounded-lg p-3 transition cursor-pointer ${
+                        isActiveGroup
+                          ? "border-[#0F3B2E] bg-[#ecfdf5] shadow-sm"
+                          : "border-[#e2e8f0] bg-[#f8fafc] hover:border-[#94a3b8]"
+                      }`}
                     >
-                      ×
-                    </button>
-                  </span>
-                ))}
+                      <div className="flex items-center justify-between gap-2">
+                        <p className="text-sm font-semibold text-[#1e293b]">
+                          {group.name} ({entries.length} option{entries.length !== 1 ? "s" : ""})
+                          {isActiveGroup && (
+                            <span className="ml-2 text-xs font-medium text-[#0F3B2E]">
+                              Active
+                            </span>
+                          )}
+                        </p>
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            removeGroup(group.id);
+                          }}
+                          className="text-xs text-red-600 hover:text-red-700"
+                        >
+                          X
+                        </button>
+                      </div>
+                      {entries.length > 0 ? (
+                        <div className="flex flex-wrap gap-2 mt-2">
+                          {entries.map(([courseKey, sections]) => (
+                            <span
+                              key={courseKey}
+                              className="inline-flex items-center gap-1 px-2.5 py-1 bg-[#0F3B2E] text-white text-xs font-medium rounded-full"
+                            >
+                              {courseKey} ({sections.length})
+                              <button
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  removeCourseFromGroup(group.id, courseKey);
+                                }}
+                                className="ml-0.5 hover:text-red-200 transition"
+                              >
+                                ×
+                              </button>
+                            </span>
+                          ))}
+                        </div>
+                      ) : (
+                        <p className="text-xs text-[#64748b] mt-2">
+                          Add one or more course options to this group.
+                        </p>
+                      )}
+                    </div>
+                  );
+                })}
               </div>
             )}
           </div>
 
           {/* 2. Preferences */}
-          {selectedCount > 0 && (
+          {configuredGroupCount > 0 && (
             <div>
               <h3 className="text-sm font-semibold text-[#1e293b] mb-3">
                 2. Preferences (optional)
@@ -399,7 +707,7 @@ export default function QuickPlanner({
           )}
 
           {/* Generate button */}
-          {selectedCount > 0 && (
+          {configuredGroupCount > 0 && (
             <button
               onClick={handleGenerate}
               disabled={generating}

--- a/Frontend/src/components/QuickPlanner/QuickPlanner.jsx
+++ b/Frontend/src/components/QuickPlanner/QuickPlanner.jsx
@@ -646,22 +646,22 @@ export default function QuickPlanner({
                       {entries.length > 0 ? (
                         <div className="flex flex-wrap gap-2 mt-2">
                           {entries.map(([courseKey, sections]) => (
-                            <span
+                  <span
                               key={courseKey}
-                              className="inline-flex items-center gap-1 px-2.5 py-1 bg-[#0F3B2E] text-white text-xs font-medium rounded-full"
-                            >
+                    className="inline-flex items-center gap-1 px-2.5 py-1 bg-[#0F3B2E] text-white text-xs font-medium rounded-full"
+                  >
                               {courseKey} ({sections.length})
-                              <button
+                    <button
                                 onClick={(e) => {
                                   e.stopPropagation();
                                   removeCourseFromGroup(group.id, courseKey);
                                 }}
-                                className="ml-0.5 hover:text-red-200 transition"
-                              >
-                                ×
-                              </button>
-                            </span>
-                          ))}
+                      className="ml-0.5 hover:text-red-200 transition"
+                    >
+                      ×
+                    </button>
+                  </span>
+                ))}
                         </div>
                       ) : (
                         <p className="text-xs text-[#64748b] mt-2">
@@ -805,7 +805,7 @@ export default function QuickPlanner({
                               {c.courseCode}
                             </span>
                             <span className="text-[#475569] whitespace-nowrap">
-                              {formatMeetingDaysForDisplay(c.meetingDays)} {c.meetingTime}
+                              {c.meetingDays} {c.meetingTime}
                             </span>
                             <span className="text-[#64748b] text-xs truncate min-w-0">
                               {c.instructor}

--- a/Frontend/src/components/QuickPlanner/QuickPlanner.jsx
+++ b/Frontend/src/components/QuickPlanner/QuickPlanner.jsx
@@ -4,6 +4,7 @@ import {
   parseTo24h,
   timeToFloat,
   estimateDuration,
+  formatMeetingDaysForDisplay,
 } from "../../utils/courseUtils";
 import ComparePlans from "../ComparePlans/ComparePlans";
 
@@ -496,7 +497,7 @@ export default function QuickPlanner({
                               {c.courseCode}
                             </span>
                             <span className="text-[#475569] whitespace-nowrap">
-                              {c.meetingDays} {c.meetingTime}
+                              {formatMeetingDaysForDisplay(c.meetingDays)} {c.meetingTime}
                             </span>
                             <span className="text-[#64748b] text-xs truncate min-w-0">
                               {c.instructor}

--- a/Frontend/src/components/WeeklySchedule/WeeklySchedule.jsx
+++ b/Frontend/src/components/WeeklySchedule/WeeklySchedule.jsx
@@ -31,7 +31,7 @@ const WeeklySchedule = forwardRef(({ registered, conflicts = new Set() }, ref) =
   const conflictCount = conflicts.size;
 
   const timeLabels = [];
-  for (let hour = START_HOUR; hour <= END_HOUR; hour++) {
+  for (let hour = START_HOUR; hour < END_HOUR; hour++) {
     const period = hour >= 12 ? "PM" : "AM";
     const display = hour > 12 ? hour - 12 : hour === 0 ? 12 : hour;
     timeLabels.push(`${display}:00 ${period}`);

--- a/Frontend/src/pages/AdminPage/AdminPage.jsx
+++ b/Frontend/src/pages/AdminPage/AdminPage.jsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import CourseSearch from "../../components/CourseSearch/CourseSearch";
 import WeeklySchedule from "../../components/WeeklySchedule/WeeklySchedule";
-import { detectConflicts } from "../../utils/courseUtils";
+import { detectConflicts, formatMeetingDaysForDisplay } from "../../utils/courseUtils";
 import wayneLogo from "../../assets/images/wayneLogo.png";
 
 function normalizePlanCourse(c) {
@@ -275,7 +275,7 @@ function AdminPage() {
                                   {course.name}
                                 </p>
                                 <p className="text-xs text-[#64748b] break-words whitespace-normal">
-                                  {course.courseCode} · {course.credits} cr · {course.meetingDays} {course.meetingTime}
+                                  {course.courseCode} · {course.credits} cr · {formatMeetingDaysForDisplay(course.meetingDays)} {course.meetingTime}
                                 </p>
                               </div>
                               <button

--- a/Frontend/src/pages/HomePage/HomePage.jsx
+++ b/Frontend/src/pages/HomePage/HomePage.jsx
@@ -15,6 +15,11 @@ function getQuickPlannerStateStorageKey(user) {
   return `quickPlannerState_${user}`;
 }
 
+const TERM_ID_TO_LABEL = {
+  "202601": "Spring/Summer 2026",
+  "202609": "Fall 2026",
+};
+
 function normalizeCourse(raw) {
   return {
     ...raw,
@@ -101,6 +106,22 @@ function HomePage() {
   }, [username]);
 
   const conflicts = useMemo(() => detectConflicts(registered), [registered]);
+
+  const scheduleTerm = useMemo(() => {
+    if (registered.length === 0) return "";
+    const terms = new Set(registered.map((c) => c.term).filter(Boolean));
+    if (terms.size === 1) {
+      const termId = [...terms][0];
+      return TERM_ID_TO_LABEL[termId] || "";
+    }
+    return "";
+  }, [registered]);
+
+  const hasMixedTerms = useMemo(() => {
+    if (registered.length <= 1) return false;
+    const terms = new Set(registered.map((c) => c.term).filter(Boolean));
+    return terms.size > 1;
+  }, [registered]);
 
   const handleAddCourse = (course) => {
     setRegistered((prev) => [...prev, course]);
@@ -322,12 +343,15 @@ function HomePage() {
             </button>
             <button
               onClick={handleRegister}
-              disabled={registerLoading || registered.length === 0}
+              disabled={registerLoading || registered.length === 0 || hasMixedTerms}
+              title={hasMixedTerms ? "Cannot register courses from different semesters" : ""}
               className={`px-3 py-1.5 text-xs font-medium rounded-md transition border ${
                 registerStatus === "registered"
                   ? "bg-green-600 border-green-500 text-white"
                   : registerStatus === "error"
                   ? "bg-red-600 border-red-500 text-white"
+                  : hasMixedTerms
+                  ? "bg-gray-400 border-gray-300 text-white cursor-not-allowed"
                   : "bg-[#b45309] border-[#d97706] text-white hover:bg-[#92400e] disabled:opacity-40"
               }`}
             >
@@ -337,6 +361,8 @@ function HomePage() {
                 ? "Registered!"
                 : registerStatus === "error"
                 ? "Failed"
+                : hasMixedTerms
+                ? "Mixed Terms"
                 : "Register"}
             </button>
           </div>
@@ -497,6 +523,7 @@ function HomePage() {
             onAddCourse={handleAddCourse}
             onRemoveCourse={handleRemoveCourse}
             conflicts={conflicts}
+            scheduleTerm={scheduleTerm}
           />
         </div>
 

--- a/Frontend/src/pages/HomePage/HomePage.jsx
+++ b/Frontend/src/pages/HomePage/HomePage.jsx
@@ -12,6 +12,10 @@ function getQuickPlanStorageKey(user) {
   return `quickPlans_${user}`;
 }
 
+function getQuickPlannerStateStorageKey(user) {
+  return `quickPlannerState_${user}`;
+}
+
 function normalizeCourse(raw) {
   return {
     ...raw,
@@ -31,6 +35,7 @@ function HomePage() {
   const [planLoading, setPlanLoading] = useState(false);
   const [showQuickPlanner, setShowQuickPlanner] = useState(false);
   const [savedQuickPlans, setSavedQuickPlans] = useState([]);
+  const [savedQuickPlannerState, setSavedQuickPlannerState] = useState(null);
   const [showAdminOverride, setShowAdminOverride] = useState(false);
   const [registerLoading, setRegisterLoading] = useState(false);
   const [registerStatus, setRegisterStatus] = useState("");
@@ -60,6 +65,20 @@ function HomePage() {
         const parsed = JSON.parse(raw);
         if (Array.isArray(parsed) && parsed.length > 0) {
           setSavedQuickPlans(parsed);
+        }
+      }
+    } catch {
+      /* ignore corrupt data */
+    }
+  }, [username]);
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(getQuickPlannerStateStorageKey(username));
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === "object") {
+          setSavedQuickPlannerState(parsed);
         }
       }
     } catch {
@@ -210,6 +229,18 @@ function HomePage() {
   const handleApplyQuickPlan = (plan) => {
     setRegistered(plan);
     setShowQuickPlanner(false);
+  };
+
+  const handleSaveQuickPlannerState = (state) => {
+    setSavedQuickPlannerState(state);
+    try {
+      localStorage.setItem(
+        getQuickPlannerStateStorageKey(username),
+        JSON.stringify(state)
+      );
+    } catch {
+      /* storage full — silent fail */
+    }
   };
 
   useEffect(() => {
@@ -502,6 +533,8 @@ function HomePage() {
           onApplyPlan={handleApplyQuickPlan}
           savedPlans={savedQuickPlans}
           onSavePlans={handleSaveQuickPlans}
+          savedPlannerState={savedQuickPlannerState}
+          onSavePlannerState={handleSaveQuickPlannerState}
         />
       )}
 

--- a/Frontend/src/pages/HomePage/HomePage.jsx
+++ b/Frontend/src/pages/HomePage/HomePage.jsx
@@ -4,7 +4,6 @@ import CourseSearch from "../../components/CourseSearch/CourseSearch";
 import WeeklySchedule from "../../components/WeeklySchedule/WeeklySchedule";
 import MySchedule from "../../components/MySchedule/MySchedule";
 import QuickPlanner from "../../components/QuickPlanner/QuickPlanner";
-import AdminOverride from "../../components/AdminOverride/AdminOverride";
 import { detectConflicts } from "../../utils/courseUtils";
 import wayneLogo from "../../assets/images/wayneLogo.png";
 
@@ -36,7 +35,6 @@ function HomePage() {
   const [showQuickPlanner, setShowQuickPlanner] = useState(false);
   const [savedQuickPlans, setSavedQuickPlans] = useState([]);
   const [savedQuickPlannerState, setSavedQuickPlannerState] = useState(null);
-  const [showAdminOverride, setShowAdminOverride] = useState(false);
   const [registerLoading, setRegisterLoading] = useState(false);
   const [registerStatus, setRegisterStatus] = useState("");
   const [showLoadModal, setShowLoadModal] = useState(false);
@@ -49,8 +47,6 @@ function HomePage() {
   const navigate = useNavigate();
 
   const username = localStorage.getItem("username") || "";
-  const userRole = localStorage.getItem("userRole") || "";
-  const isAdmin = userRole === "admin";
 
   useEffect(() => {
     if (localStorage.getItem("userRole") === "admin") {
@@ -303,14 +299,6 @@ function HomePage() {
           </div>
 
           <div className="flex items-center gap-2">
-            {isAdmin && (
-              <button
-                onClick={() => setShowAdminOverride(true)}
-                className="px-3 py-1.5 text-xs font-medium text-white bg-red-700 border border-red-500 rounded-md hover:bg-red-800 transition"
-              >
-                Admin Override
-              </button>
-            )}
             <button
               onClick={() => setShowQuickPlanner(true)}
               className="relative px-3 py-1.5 text-xs font-medium text-white bg-[#2563eb] border border-[#3b82f6] rounded-md hover:bg-[#1d4ed8] transition"
@@ -538,9 +526,6 @@ function HomePage() {
         />
       )}
 
-      {showAdminOverride && (
-        <AdminOverride onClose={() => setShowAdminOverride(false)} />
-      )}
     </div>
   );
 }

--- a/Frontend/src/utils/courseUtils.js
+++ b/Frontend/src/utils/courseUtils.js
@@ -19,6 +19,30 @@ export function parseMeetingDays(meetingDaysStr) {
 }
 
 /**
+ * UI display helper: keep internal day code as "R" but show Thursday as "TR".
+ */
+export function formatMeetingDaysForDisplay(meetingDaysStr) {
+  if (!meetingDaysStr) return "";
+  const normalized = String(meetingDaysStr).trim();
+  if (!normalized) return "";
+  // Only convert compact day-code strings like "MWF" or "TR".
+  if (!/^[MTWRF]+$/.test(normalized)) return normalized;
+
+  const displayMap = {
+    M: "M",
+    T: "TU",
+    W: "W",
+    R: "TR",
+    F: "F",
+  };
+
+  return normalized
+    .split("")
+    .map((ch) => displayMap[ch] || ch)
+    .join(" ");
+}
+
+/**
  * Convert 12h time string to 24h "HH:MM" format
  * e.g. "10:00 AM" → "10:00", "2:00 PM" → "14:00"
  */


### PR DESCRIPTION
## Summary
Implement Quick Planner schedule generation with user-defined option groups, compare plans, and fix related bugs found during integration.

## Changes
- Rebuild Quick Planner around user-defined option groups with persistent state per user
- Add Compare Plans side-by-side view for generated schedules
- Enforce semester selection before course search to prevent cross-term registration
- Update seat counts in `section.registered` only on register (not save) with capacity check and row-level locking
- Remove unreachable Admin Override code from HomePage
- Fix undefined `formatMeetingDaysForDisplay` reference in QuickPlanner
- Fix exported PDF weekly layout to match on-screen scheduler
- Align compare-plan mini schedule rendering and color mapping
- Guard start-time constraints against sections without meeting time
- Align schedule blocks with displayed hour grid
- Improve weekday display readability

## Type of Change
- [x] New feature
- [x] Bug fix
- [x] Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Configuration

## Screenshots (if applicable)

## Related Issue
Closes #8

## Deployment
- Deployment URL: 

## Additional Notes
- Seat availability is now enforced at the DB level: `section.registered` is incremented/decremented only when a user registers (not saves), preventing one user from occupying multiple seats across saved plans.
- `FOR UPDATE` row lock prevents race conditions on concurrent registration.
- Fall 2026 (`term_id=202609`) has no data in the database; only Spring/Summer 2026 is currently available.